### PR TITLE
Eliminate _ case params from `/routes` et al, userHistory -> user_his…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1154,11 +1154,6 @@
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
       "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo="
     },
-    "camelcase": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
-    },
     "caseless": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "babel-runtime": "^6.6.1",
     "bluebird": "^3.3.3",
     "boom": "^5.1.0",
-    "camelcase": "^4.1.0",
     "code": "^4.0.0",
     "commonmark": "^0.26.0",
     "dateformat": "^2.0.0",

--- a/src/lib/endpoints/transactions.js
+++ b/src/lib/endpoints/transactions.js
@@ -1080,8 +1080,9 @@ it as fsck for transactions)`
     }
   })
 
-  routeRequestsTo(server, ["/transactions/userHistory", "/transactions/user_history"], {
+  server.route({
     method: "GET",
+    path: "/transactions/user_history",
     config: {
       tags: ["api"],
       description:

--- a/test/transactionHistory.js
+++ b/test/transactionHistory.js
@@ -333,7 +333,7 @@ lab.experiment("Transactions", function () {
 
     var user1History = (await server.inject({
       method: 'GET',
-      url: '/transactions/userHistory',
+      url: '/transactions/user_history',
       headers: {
         authorization: `Bearer ${user.makeToken()}`
       }
@@ -389,7 +389,7 @@ lab.experiment("Transactions", function () {
 
     var user1History = (await server.inject({
       method: 'GET',
-      url: '/transactions/userHistory',
+      url: '/transactions/user_history',
       headers: {
         authorization: `Bearer ${user.makeToken()}`
       }


### PR DESCRIPTION
…tory

* Remove all _ case params from `/routes` and `/routes/{id}`,
and logic to convert them into camel case

* Remove camelcase as a dependency as we don't need it anymore

* `/transactions/userHistory` -> `/transactions/user_history`