### PR TITLE
Ticket voiding - prep work

### DIFF
--- a/src/lib/endpoints/routePassAdmin.js
+++ b/src/lib/endpoints/routePassAdmin.js
@@ -26,7 +26,7 @@ export function register (server, options, next) {
     ),
   })
 
-  const authorizeRouteManager = authorizeByRole('manage-routes', r => r.params.companyId)
+  const authorizeRouteManager = authorizeByRole('manage-routes', (p, r) => r.params.companyId)
 
   server.route({
     method: "GET",

--- a/src/lib/endpoints/tickets.js
+++ b/src/lib/endpoints/tickets.js
@@ -1,25 +1,18 @@
-var _ = require("lodash")
-var Joi = require("joi")
-var toSVY = require("../util/svy21").toSVY
-var toWGS = require("../util/svy21").toWGS
-var common = require("../util/common")
-var Boom = require("boom")
-var tickets = []
-
-
-// / N.B. stops cannot be retrieved directly
+const Joi = require('joi')
+const Boom = require('boom')
+const common = require('../util/common')
 
 export function register (server, options, next) {
   server.route({
-    method: "GET",
-    path: "/tickets",
+    method: 'GET',
+    path: '/tickets',
     config: {
-      tags: ["api"],
-      description: "Update a route (for admin and superadmin only)",
+      tags: ['api'],
+      description: 'Update a route (for admin and superadmin only)',
       auth: {access: {scope: ['user']}},
       validate: {
         query: Joi.object({
-          startTime: Joi.date().default(() => common.midnightToday(), "0000hrs today"),
+          startTime: Joi.date().default(() => common.midnightToday(), '0000hrs today'),
           transportCompanyId: Joi.number().integer().optional()
         }).unknown()
       }
@@ -31,12 +24,12 @@ export function register (server, options, next) {
       var ticketQuery = {
         where: {
           userId: request.auth.credentials.userId,
-          status: "valid"
+          status: 'valid'
         },
         include: [
           {
             model: m.TripStop,
-            as: "boardStop",
+            as: 'boardStop',
             include: [m.Stop,
               {
                 model: m.Trip,
@@ -55,13 +48,13 @@ export function register (server, options, next) {
           },
           {
             model: m.TripStop,
-            as: "alightStop",
+            as: 'alightStop',
             include: [m.Stop, m.Trip],
             required: false
           }
         ],
         order: [
-          [{model: m.TripStop, as: "boardStop"}, "time", "ASC"]
+          [{model: m.TripStop, as: 'boardStop'}, 'time', 'ASC']
         ]
       }
 
@@ -78,10 +71,10 @@ export function register (server, options, next) {
   })
 
   server.route({
-    method: "GET",
-    path: "/tickets/{id}",
+    method: 'GET',
+    path: '/tickets/{id}',
     config: {
-      tags: ["api"],
+      tags: ['api'],
       auth: {access: {scope: ['user']}},
       validate: {
         params: {
@@ -97,17 +90,17 @@ export function register (server, options, next) {
           where: {
             id: request.params.id,
             userId: request.auth.credentials.userId,
-            status: "valid"
+            status: 'valid'
           },
           include: [
             {
               model: m.TripStop,
-              as: "boardStop",
+              as: 'boardStop',
               include: [m.Stop, m.Trip]
             },
             {
               model: m.TripStop,
-              as: "alightStop",
+              as: 'alightStop',
               include: [m.Stop, m.Trip]
             }
           ]
@@ -122,5 +115,5 @@ export function register (server, options, next) {
 }
 
 register.attributes = {
-  name: "endpoint-tickets"
+  name: 'endpoint-tickets'
 }

--- a/src/lib/util/endpoints.js
+++ b/src/lib/util/endpoints.js
@@ -119,9 +119,9 @@ const reduceCallbacksWith = (initial, request, context, callbacks) => callbacks.
   Promise.resolve(initial)
 )
 
-export const authorizeByRole = (role, lookupId = request => request.params.id) =>
+export const authorizeByRole = (role, lookupId = (passthrough, request) => request.params.id) =>
   (passthrough, request) => {
-    auth.assertAdminRole(request.auth.credentials, role, lookupId(request))
+    auth.assertAdminRole(request.auth.credentials, role, lookupId(passthrough, request))
     return passthrough
   }
 

--- a/src/lib/util/endpoints.js
+++ b/src/lib/util/endpoints.js
@@ -1,5 +1,6 @@
 const Boom = require("boom")
 const _ = require("lodash")
+const assert = require("assert")
 
 const {NotFoundError, defaultErrorHandler, getDB, getModels} = require("../util/common")
 const auth = require("../core/auth")
@@ -127,7 +128,10 @@ export const authorizeByRole = (role, lookupId = (passthrough, request) => reque
 
 export const instToJSONOrNotFound = inst => inst ? inst.toJSON() : Boom.notFound()
 
-export const assertThat = (f, { assert }, msg) => inst => { assert(f(inst), msg); return inst }
+export const assertThat = (f, ErrorType, msg) => {
+  assert(Error.prototype.isPrototypeOf(new ErrorType()) && typeof ErrorType.assert === 'function')
+  return inst => { ErrorType.assert(f(inst), msg); return inst }
+}
 
 export const assertFound = assertThat(inst => inst, NotFoundError, 'Item not found')
 

--- a/src/lib/util/endpoints.js
+++ b/src/lib/util/endpoints.js
@@ -127,7 +127,9 @@ export const authorizeByRole = (role, lookupId = request => request.params.id) =
 
 export const instToJSONOrNotFound = inst => inst ? inst.toJSON() : Boom.notFound()
 
-export const assertFound = inst => { NotFoundError.assert(inst); return inst }
+export const assertThat = (f, { assert }, msg) => inst => { assert(f(inst), msg); return inst }
+
+export const assertFound = assertThat(inst => inst, NotFoundError, 'Item not found')
 
 export const deleteInst = async inst => {
   if (inst) {


### PR DESCRIPTION
* `endpoints/tickets` - Clean up dependencies, “ -> ‘
* `util/endpoints` - Extract a more general assert function, refactor `assertFound` to use it
* `test/tickets` - Re-jig in prep for new status change functionality
* `authorizeByRole` - let `lookupId` callback take passthrough and request