### PR TITLE
ticket sales - Identify duplicate tickets by id

### DIFF
--- a/src/lib/transactions/index.js
+++ b/src/lib/transactions/index.js
@@ -873,10 +873,12 @@ export var checkValidBookingWindow = (...args) => checkStopsAndBookingWindow(tru
 
 export function checkNoDuplicates () {
   return (dbTrip, rqTrip) => {
-    var dbTripTickets = _.flatten(dbTrip.tripStops.map(ts => ts.tickets))
-
-    if (dbTripTickets.some(ticket => (ticket.status === "valid" || ticket.status === 'pending' || ticket.status === 'bidded') && ticket.userId === rqTrip.userId)) {
-      throw new TransactionError(`User #${rqTrip.userId} already has a ticket for the trip`)
+    const dbTripTickets = _.flatten(dbTrip.tripStops.map(ts => ts.tickets))
+    const existingTicketFromUser = dbTripTickets.find(
+      ticket => (ticket.status === 'valid' || ticket.status === 'pending') && ticket.userId === rqTrip.userId
+    )
+    if (existingTicketFromUser) {
+      throw new TransactionError(`User #${rqTrip.userId} already has ticket [${existingTicketFromUser.id}] for the trip`)
     }
   }
 }


### PR DESCRIPTION
* If the user already purchased a ticket for a trip, identify that ticket by id in the transaction error
* Remove bidded status check as we no longer user tickets for crowdstart bids