### PR TITLE
Cleanup and re-org auth0 env vars

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -31,6 +31,7 @@ var required_variables = [
   'TWILIO_ACCOUNT_SID',
   'TWILIO_AUTH_TOKEN',
   'DATABASE_URL',
+  'AUTH0_SECRET',
 ]
 var warn_variables = [
   'STRIPE_PK',
@@ -38,8 +39,6 @@ var warn_variables = [
   'STRIPE_SK',
   'AUTH0_CID',
   'AUTH0_DOMAIN',
-  'AUTH0_SECRET',
-  'AUTH0_TOKEN_USERREAD',
 ]
 for (let v of required_variables) {
   if (!process.env[v]) {

--- a/src/lib/core/auth.js
+++ b/src/lib/core/auth.js
@@ -1,7 +1,6 @@
-export var auth0Secret = process.env.AUTH0_SECRET.trim()
+export var auth0Secret = process.env.AUTH0_SECRET
 export var secretKey = auth0Secret
 export var emailVerificationKey = auth0Secret
-export var auth0Auth = process.env.AUTH0_TOKEN_USERREAD
 export var auth0Domain = process.env.AUTH0_DOMAIN
 
 const Joi = require("joi")


### PR DESCRIPTION
* Eliminate `AUTH0_TOKEN_USERREAD` as it’s no longer used
* Make `AUTH0_SECRET` mandatory, and use as-is, ie, no trim