### PR TITLE
Add support for read replicas

### DIFF
--- a/src/lib/core/dbschema.js
+++ b/src/lib/core/dbschema.js
@@ -1,5 +1,7 @@
 const _ = require('lodash')
 const Sequelize = require("sequelize")
+const assert = require('assert')
+
 const config = require("../../config")
 
 var cache = null
@@ -87,7 +89,9 @@ function dbLogin () {
     }
   }
   function parseReplica (replica) {
-    let parts = replica.match(/^postgres:\/\/(.*):(.*)@(.*):([0-9]{0,6})\/(.*)$/)
+    // postgres URLs take the form postgres://user:password@host:port/database
+    const parts = replica.match(/^postgres:\/\/(.+):(.+)@(.+):([0-9]{1,6})\/(.+)$/)
+    assert(parts)
     const [, username, password, host, port, database] = parts
     return {host, port: port || '5432', username, password, database}
   }

--- a/src/lib/core/dbschema.js
+++ b/src/lib/core/dbschema.js
@@ -93,7 +93,7 @@ function dbLogin () {
     const parts = replica.match(/^postgres:\/\/(.+):(.+)@(.+):([0-9]{1,6})\/(.+)$/)
     assert(parts)
     const [, username, password, host, port, database] = parts
-    return {host, port: port || '5432', username, password, database}
+    return {host, port, username, password, database}
   }
   if (replicas.length > 0) {
     sequelizeOptions = {

--- a/src/lib/custom/wrs.js
+++ b/src/lib/custom/wrs.js
@@ -620,7 +620,7 @@ export function register (server, options, next) {
 
     writer.pipe(io)
 
-    db.transaction(async (t) => {
+    db.transaction({readOnly: true}, async (t) => {
       let offset = 0
       let batchSize = 100
       while (true) {

--- a/src/lib/endpoints/suggestions.js
+++ b/src/lib/endpoints/suggestions.js
@@ -83,7 +83,7 @@ export function register (server, options, next) {
           io.end()
         } else {
           io.write('[\n')
-          db.transaction(async (t) => {
+          db.transaction({readOnly: true}, async (t) => {
             let offset = 0
             const limit = 1000
             var numWritten = 0

--- a/src/lib/endpoints/transactionItems.js
+++ b/src/lib/endpoints/transactionItems.js
@@ -499,7 +499,7 @@ export function register (server, options, next) {
             .header('Content-type', 'text/csv')
             .header('content-disposition', 'attachment; filename="route_pass_report.csv"')
 
-          db.transaction(async transaction => {
+          db.transaction({readOnly: true}, async transaction => {
             const perPage = 20
             var page = 1
             var lastFetchedSize = perPage

--- a/src/lib/promotions/functions/ticketDiscountQualifiers.js
+++ b/src/lib/promotions/functions/ticketDiscountQualifiers.js
@@ -140,6 +140,11 @@ export const qualifyingFunctions = {
       const contactList = await transactionBuilder.models.ContactList
         .findById(validatedParams.contactListId, {transaction: transactionBuilder.transaction})
 
+      if (!contactList) {
+        console.warn(`limitByContactList - Unrecognised contact list id: ${validatedParams.contactListId}`)
+        return []
+      }
+
       const telephoneListKeyed = _.keyBy(contactList.telephones)
       const emailListKeyed = _.keyBy(contactList.emails)
 


### PR DESCRIPTION
* dbschema - if there are env vars prefixed with `HEROKU_POSTGRESQL`,
assume these are databases that are attached to the server,
and parse and feed into sequelize options as replicas. Sequelize will then
use one of the read replicas when making queries

* Mark db.transaction invocations as read-only, where appropriate

This commit was written while paired with @xkjyeah

This uses code taken from datagovsg/beeline-server-archive#214

NOTE: Read-replicas may not always catch up to master, so thus,
any changes made to master may not always be reflected in the replicas.
This might become a problem in situations where the user may want to see
a recent change made, eg, after a ticket purchase, or after an operator issues a refund