### PR TITLE
 Enable non-prod deployments to AWS Elastic Beanstalk

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.ebignore
+++ b/.ebignore
@@ -1,0 +1,2 @@
+Dockerfile
+.git

--- a/.ebignore
+++ b/.ebignore
@@ -1,2 +1,1 @@
 Dockerfile
-.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,17 @@ deploy:
     on:
       branch: production
       condition: "$BABEL_ENV = awslambda"
+
+  - provider: elasticbeanstalk
+    access_key_id: $AWS_ACCESS_KEY_ID
+    secret_access_key: $AWS_SECRET_ACCESS_KEY
+    region: "ap-southeast-1"
+    app: "beeline-server"
+    env: "beeline-server-dev"
+    bucket_name: "elasticbeanstalk-ap-southeast-1-882000534153"
+    on:
+      branch: $DEV_BRANCH
+      condition: "$BABEL_ENV = web"
 addons:
   postgresql: '9.6'
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,9 @@ before_deploy:
       docker tag $REPO:$TRAVIS_COMMIT $REPO:travis-$TRAVIS_BUILD_NUMBER;
       docker push $REPO;
       sed -i -e "s/@TAG/$TAG/g" Dockerrun.aws.json;
-      rm -f Dockerfile;
+      git ls-files --ignored --exclude-from=.ebignore -z | xargs -0 git rm -f;
+      git ls-files --ignored --exclude-from=.ebignore -z | xargs -0 rm -f;
+      git rm -f .ebignore;
     fi
 deploy:
   - provider: lambda

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+services:
+  - docker
+
 language: node_js
 node_js:
 - '8'
@@ -16,8 +19,18 @@ script:
   - echo Linting the following JS files in this branch - `git diff --name-only origin/master -- '*.js'`
   - ./node_modules/eslint/bin/eslint.js --max-warnings 0 `git diff --name-only origin/master -- '*.js'`
 before_deploy:
-  - npm install -g babel
-  - npm run build
+  - if [ "$BABEL_ENV" == "awslambda" ]; then npm install && npm run build -g babel; fi
+  - if [ "$BABEL_ENV" == "web" ]; then
+      docker login -u $DOCKER_USER -p $DOCKER_PASSWORD;
+      export REPO=$TRAVIS_REPO_SLUG;
+      export TAG=`if [ "$TRAVIS_BRANCH" == "production" ]; then echo "latest"; else echo $TRAVIS_BRANCH ; fi`;
+      echo "Building image $REPO:$TAG";
+      docker build -f Dockerfile -t $REPO:$TRAVIS_COMMIT .;
+      docker tag $REPO:$TRAVIS_COMMIT $REPO:$TAG;
+      docker tag $REPO:$TRAVIS_COMMIT $REPO:travis-$TRAVIS_BUILD_NUMBER;
+      docker push $REPO;
+      sed -i -e "s/@TAG/$TAG/g" Dockerrun.aws.json;
+    fi
 deploy:
   - provider: lambda
     function_name: expireStaleRoutePasses-staging

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ env:
   - CXX=g++-4.8
   - SHUTUP=1
   - TZ=Asia/Singapore
+  # Declare two Babel envs, web and awslambda. The latter transpiles to
+  # node 6.x compatible code, which AWS Lambda understands
   matrix:
   - BABEL_ENV=awslambda
   - BABEL_ENV=web
@@ -20,6 +22,8 @@ script:
   - ./node_modules/eslint/bin/eslint.js --max-warnings 0 `git diff --name-only origin/master -- '*.js'`
 before_deploy:
   - if [ "$BABEL_ENV" == "awslambda" ]; then npm install && npm run build -g babel; fi
+  # If building for the web, build out a docker image, push it to Docker Hub,
+  # then tell Elastic Beanstalk (later) of the recently pushed image
   - if [ "$BABEL_ENV" == "web" ]; then
       docker login -u $DOCKER_USER -p $DOCKER_PASSWORD;
       export REPO=$TRAVIS_REPO_SLUG;

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ before_deploy:
       docker tag $REPO:$TRAVIS_COMMIT $REPO:travis-$TRAVIS_BUILD_NUMBER;
       docker push $REPO;
       sed -i -e "s/@TAG/$TAG/g" Dockerrun.aws.json;
+      rm -f Dockerfile;
     fi
 deploy:
   - provider: lambda
@@ -64,6 +65,7 @@ deploy:
       condition: "$BABEL_ENV = awslambda"
 
   - provider: elasticbeanstalk
+    skip_cleanup: true
     access_key_id: $AWS_ACCESS_KEY_ID
     secret_access_key: $AWS_SECRET_ACCESS_KEY
     region: "ap-southeast-1"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM node:8.9.1-alpine
+
+WORKDIR /app
+
+# Copy in package.json into the image and install node modules
+# These layers are only rebuilt if package.json changes
+COPY package.json  .
+
+RUN apk add vips-dev fftw-dev --update-cache \
+  --repository https://dl-3.alpinelinux.org/alpine/edge/testing/
+
+RUN apk add --no-cache make gcc g++ python && \
+  npm install && \
+  apk del make gcc g++ python
+
+# Copy rest of source code into image
+COPY src/ src/
+COPY .babelrc .
+
+RUN npm run build && \
+  npm prune --production
+
+RUN rm -rf src
+
+RUN mkdir logs
+
+EXPOSE 10000
+ENV PORT 10000
+
+CMD node dist/index.js

--- a/Dockerrun.aws.json
+++ b/Dockerrun.aws.json
@@ -1,0 +1,9 @@
+{
+  "AWSEBDockerrunVersion": "1",
+  "Ports": [
+    {
+      "ContainerPort": "10000"
+    }
+  ],
+  "Logging": "/app/logs"
+}

--- a/Dockerrun.aws.json
+++ b/Dockerrun.aws.json
@@ -1,5 +1,9 @@
 {
   "AWSEBDockerrunVersion": "1",
+  "Image": {
+    "Name": "datagovsg/beeline-server:@TAG",
+    "Update": "true"
+  },
   "Ports": [
     {
       "ContainerPort": "10000"

--- a/src/lib/events/definitions.js
+++ b/src/lib/events/definitions.js
@@ -1,6 +1,5 @@
 import Joi from 'joi'
 import _ from 'lodash'
-import * as auth from '../core/auth'
 import assert from 'assert'
 
 const RouteNotificationParams = {


### PR DESCRIPTION
* Provide Docker-related config for Elastic Beanstalk,
and specify the appropriate deploy provider in Travis

* Remove an unused import in events/definitions as it was interfering
with `DATABASE_URL` bootstrapping

* Rework deployment pipeline to use Travis for docker builds

* Prevent Dockerfile from being consumed by EB, making provisions to address travis-ci/dpl#411