### PR TITLE
Sort tripStops in instant crowdstart test for consistency

### DIFF
--- a/test/instantCrowdstart.js
+++ b/test/instantCrowdstart.js
@@ -153,22 +153,22 @@ lab.experiment("Instant Crowdstarts", function () {
     expect(route.from).equal(`Bus Stop 3073`)
     expect(route.to).equal(`Bus Stop 211`)
 
-    const tripStops = route.trips[0].tripStops
+    const tripStops = _.sortBy(route.trips[0].tripStops, ts => ts.time)
 
     expect(tripStops.length).equal(stops.length)
     expect(midnightOffset(tripStops[tripStops.length - 1].time)).equal(7.5 * 3600 * 1000)
     expect(midnightOffset(tripStops[0].time)).equal(7.5 * 3600 * 1000 - 1600 - 60000 * 7)
 
-    route.trips[0].tripStops.slice(0, 4)
+    tripStops.slice(0, 4)
       .forEach(ts => expect(ts.canBoard && !ts.canAlight).true())
-    route.trips[0].tripStops.slice(4)
+    tripStops.slice(4)
       .forEach(ts => expect(!ts.canBoard && ts.canAlight).true())
 
     // Check the stop description
     stops.forEach(sindex => {
-      expect(route.trips[0].tripStops.some(ts => ts.stop.description === `Bus Stop ${sindex}`)).true()
+      expect(tripStops.some(ts => ts.stop.description === `Bus Stop ${sindex}`)).true()
     })
-    expect(route.trips[0].tripStops.length).equal(stops.length)
+    expect(tripStops.length).equal(stops.length)
   })
 
   lab.test("Anyone can preview crowdstart route", {timeout: 30000}, async function () {


### PR DESCRIPTION
Database results are not necessarily sorted by time. Therefore sort them