### PR TITLE
No credit tag, legacy payment endpoints

### DIFF
--- a/src/lib/endpoints/transactions.js
+++ b/src/lib/endpoints/transactions.js
@@ -52,200 +52,191 @@ const INVALID_CREDIT_TAGS = [
 ]
 
 export const register = (server, options, next) => {
-  routeRequestsTo(
-    server,
-    ["/transactions/tickets/payment"],
-    {
-      method: "POST",
-      config: {
-        tags: ["api"],
-        description: `Prepare a transaction with tickets, charge Stripe, and then mark the
+  routeRequestsTo(server, ["/transactions/tickets/payment"], {
+    method: "POST",
+    config: {
+      tags: ["api"],
+      description: `Prepare a transaction with tickets, charge Stripe, and then mark the
   transaction as committed and the tickets as valid if Stripe has been
   successfully charged.`,
-        validate: {
-          payload: {
-            trips: Joi.array().items(
-              Joi.object({
-                tripId: Joi.number().integer(),
-                // qty: Joi.number().integer().default(1).min(1).max(1),
-                boardStopId: Joi.number().integer(),
-                alightStopId: Joi.number().integer(),
-              })
-            ),
-            promoCode: Joi.object({
-              code: Joi.string()
-                .allow("")
-                .required(),
-              options: Joi.object(),
-            }).allow(null),
-            applyRoutePass: Joi.boolean().default(false),
-            applyReferralCredits: Joi.boolean().default(false),
-            applyCredits: Joi.boolean().default(false),
-            stripeToken: Joi.string(),
-            customerId: Joi.string(),
-            sourceId: Joi.string(),
-            expectedPrice: Joi.number().allow(null),
-          },
+      validate: {
+        payload: {
+          trips: Joi.array().items(
+            Joi.object({
+              tripId: Joi.number().integer(),
+              // qty: Joi.number().integer().default(1).min(1).max(1),
+              boardStopId: Joi.number().integer(),
+              alightStopId: Joi.number().integer(),
+            })
+          ),
+          promoCode: Joi.object({
+            code: Joi.string()
+              .allow("")
+              .required(),
+            options: Joi.object(),
+          }).allow(null),
+          applyRoutePass: Joi.boolean().default(false),
+          applyReferralCredits: Joi.boolean().default(false),
+          applyCredits: Joi.boolean().default(false),
+          stripeToken: Joi.string(),
+          customerId: Joi.string(),
+          sourceId: Joi.string(),
+          expectedPrice: Joi.number().allow(null),
         },
       },
-      async handler(request, reply) {
-        let db = getDB(request)
-        let m = getModels(request)
+    },
+    async handler(request, reply) {
+      let db = getDB(request)
+      let m = getModels(request)
 
-        try {
-          // Add the user id to the trip orders
-          if (!options.dryRun && request.auth.credentials.scope !== "user") {
-            throw new SecurityError("Need to be logged in to make transaction")
-          }
-          for (let trip of request.payload.trips) {
-            trip.userId = request.auth.credentials.userId
-          }
-
-          // check payload has either stripe token or customerId
-          if (
-            !request.payload.stripeToken &&
-            (!request.payload.customerId || !request.payload.sourceId)
-          ) {
-            throw new InvalidArgumentError(
-              "No stripe token or customerId is provided"
-            )
-          }
-
-          /* Prepare the transaction */
-          let [dbTxn, undoFn] = await prepareTicketSale([db, m], {
-            trips: request.payload.trips,
-            promoCode: request.payload.promoCode,
-            applyRoutePass: request.payload.applyRoutePass,
-            applyReferralCredits: request.payload.applyReferralCredits,
-            applyCredits: request.payload.applyCredits,
-            dryRun: false,
-            committed: true,
-            convertToJson: false,
-            expectedPrice: request.payload.expectedPrice,
-            creator: {
-              type: "user",
-              id: request.auth.credentials.userId,
-            },
-          })
-
-          assert(dbTxn.id)
-
-          let chargeOptions = {
-            db,
-            models: m,
-            transaction: dbTxn,
-            tokenIat: request.auth.credentials.iat,
-            paymentDescription: `[Txn #${dbTxn.id}] ` + dbTxn.description,
-          }
-
-          if (request.payload.stripeToken) {
-            _.assign(chargeOptions, {
-              stripeToken: request.payload.stripeToken,
-            })
-          } else if (request.payload.customerId && request.payload.sourceId) {
-            _.assign(chargeOptions, {
-              customerId: request.payload.customerId,
-              sourceId: request.payload.sourceId,
-            })
-          }
-
-          // charge stripe
-          try {
-            await chargeSale(chargeOptions)
-          } catch (err) {
-            console.error(err)
-            if (err instanceof ChargeError) {
-              try {
-                await undoFn()
-              } catch (err2) {
-                events.emit("transactionFailure", {
-                  message: `!!! ERROR UNDOING ${dbTxn.id} with ${err2.message}`,
-                  userId: request.auth.credentials.userId,
-                })
-                console.error(err2)
-              }
-            }
-            throw err
-          }
-
-          dbTxn = await m.Transaction.findById(dbTxn.id, {
-            include: [m.TransactionItem],
-          })
-          await m.TransactionItem.getAssociatedItems(dbTxn.transactionItems);
-
-          // asynchronously reload the ticket data and run the hooks
-          (async function(tis) {
-            let ticketIds = tis
-              .filter(ti => ti.ticketSale)
-              .map(ti => ti.itemId)
-
-            ticketIds.forEach(async ticketId => {
-              try {
-                let newTicketInst = await m.Ticket.findById(ticketId, {
-                  include: [
-                    { model: m.TripStop, as: "boardStop" },
-                    { model: m.TripStop, as: "alightStop" },
-                  ],
-                })
-                let newTicketTrip = await m.Trip.find({
-                  include: [
-                    {
-                      model: m.TripStop,
-                      where: { id: newTicketInst.boardStopId },
-                    },
-                    m.Route,
-                  ],
-                })
-                events.emit("newBooking", {
-                  trip: newTicketTrip,
-                  ticket: newTicketInst,
-                })
-              } catch (err) {
-                console.error(err.stack)
-              }
-            })
-          })(dbTxn.transactionItems)
-
-          let transactionItemsByType = _.groupBy(
-            dbTxn.transactionItems,
-            ti => ti.itemType
-          )
-          let numValidPromoTickets = null
-          let promotionId = null
-
-          if (transactionItemsByType.discount) {
-            let promo = transactionItemsByType.discount.filter(
-              item => item.discount.promotionId
-            )
-            assert(
-              promo.length < 2,
-              `Only 1 promotion per purchase is allowed`
-            )
-            if (promo.length === 1) {
-              promotionId = promo[0].discount.promotionId
-              numValidPromoTickets = _.keys(promo[0].notes.tickets).filter(
-                ticketId => promo[0].notes.tickets[ticketId] > 0
-              ).length
-            }
-          }
-
-          events.emit("newPurchase", {
-            userId: request.auth.credentials.userId,
-            numValidPromoTickets,
-            promotionId,
-          })
-
-          reply(dbTxn.toJSON())
-        } catch (err) {
-          events.emit("transactionFailure", {
-            message: err.message,
-            userId: request.auth.credentials.userId,
-          })
-          defaultErrorHandler(reply)(err)
+      try {
+        // Add the user id to the trip orders
+        if (!options.dryRun && request.auth.credentials.scope !== "user") {
+          throw new SecurityError("Need to be logged in to make transaction")
         }
-      },
-    }
-  )
+        for (let trip of request.payload.trips) {
+          trip.userId = request.auth.credentials.userId
+        }
+
+        // check payload has either stripe token or customerId
+        if (
+          !request.payload.stripeToken &&
+          (!request.payload.customerId || !request.payload.sourceId)
+        ) {
+          throw new InvalidArgumentError(
+            "No stripe token or customerId is provided"
+          )
+        }
+
+        /* Prepare the transaction */
+        let [dbTxn, undoFn] = await prepareTicketSale([db, m], {
+          trips: request.payload.trips,
+          promoCode: request.payload.promoCode,
+          applyRoutePass: request.payload.applyRoutePass,
+          applyReferralCredits: request.payload.applyReferralCredits,
+          applyCredits: request.payload.applyCredits,
+          dryRun: false,
+          committed: true,
+          convertToJson: false,
+          expectedPrice: request.payload.expectedPrice,
+          creator: {
+            type: "user",
+            id: request.auth.credentials.userId,
+          },
+        })
+
+        assert(dbTxn.id)
+
+        let chargeOptions = {
+          db,
+          models: m,
+          transaction: dbTxn,
+          tokenIat: request.auth.credentials.iat,
+          paymentDescription: `[Txn #${dbTxn.id}] ` + dbTxn.description,
+        }
+
+        if (request.payload.stripeToken) {
+          _.assign(chargeOptions, {
+            stripeToken: request.payload.stripeToken,
+          })
+        } else if (request.payload.customerId && request.payload.sourceId) {
+          _.assign(chargeOptions, {
+            customerId: request.payload.customerId,
+            sourceId: request.payload.sourceId,
+          })
+        }
+
+        // charge stripe
+        try {
+          await chargeSale(chargeOptions)
+        } catch (err) {
+          console.error(err)
+          if (err instanceof ChargeError) {
+            try {
+              await undoFn()
+            } catch (err2) {
+              events.emit("transactionFailure", {
+                message: `!!! ERROR UNDOING ${dbTxn.id} with ${err2.message}`,
+                userId: request.auth.credentials.userId,
+              })
+              console.error(err2)
+            }
+          }
+          throw err
+        }
+
+        dbTxn = await m.Transaction.findById(dbTxn.id, {
+          include: [m.TransactionItem],
+        })
+        await m.TransactionItem.getAssociatedItems(dbTxn.transactionItems);
+
+        // asynchronously reload the ticket data and run the hooks
+        (async function(tis) {
+          let ticketIds = tis.filter(ti => ti.ticketSale).map(ti => ti.itemId)
+
+          ticketIds.forEach(async ticketId => {
+            try {
+              let newTicketInst = await m.Ticket.findById(ticketId, {
+                include: [
+                  { model: m.TripStop, as: "boardStop" },
+                  { model: m.TripStop, as: "alightStop" },
+                ],
+              })
+              let newTicketTrip = await m.Trip.find({
+                include: [
+                  {
+                    model: m.TripStop,
+                    where: { id: newTicketInst.boardStopId },
+                  },
+                  m.Route,
+                ],
+              })
+              events.emit("newBooking", {
+                trip: newTicketTrip,
+                ticket: newTicketInst,
+              })
+            } catch (err) {
+              console.error(err.stack)
+            }
+          })
+        })(dbTxn.transactionItems)
+
+        let transactionItemsByType = _.groupBy(
+          dbTxn.transactionItems,
+          ti => ti.itemType
+        )
+        let numValidPromoTickets = null
+        let promotionId = null
+
+        if (transactionItemsByType.discount) {
+          let promo = transactionItemsByType.discount.filter(
+            item => item.discount.promotionId
+          )
+          assert(promo.length < 2, `Only 1 promotion per purchase is allowed`)
+          if (promo.length === 1) {
+            promotionId = promo[0].discount.promotionId
+            numValidPromoTickets = _.keys(promo[0].notes.tickets).filter(
+              ticketId => promo[0].notes.tickets[ticketId] > 0
+            ).length
+          }
+        }
+
+        events.emit("newPurchase", {
+          userId: request.auth.credentials.userId,
+          numValidPromoTickets,
+          promotionId,
+        })
+
+        reply(dbTxn.toJSON())
+      } catch (err) {
+        events.emit("transactionFailure", {
+          message: err.message,
+          userId: request.auth.credentials.userId,
+        })
+        defaultErrorHandler(reply)(err)
+      }
+    },
+  })
 
   routeRequestsTo(server, ["/transactions/route_passes/payment"], {
     method: "POST",
@@ -392,90 +383,86 @@ export const register = (server, options, next) => {
     },
   })
 
-  routeRequestsTo(
-    server,
-    ["/transactions/tickets/quote"],
-    {
-      method: "POST",
-      config: {
-        tags: ["api"],
-        description: `Used to preview the result of a ticket payment
+  routeRequestsTo(server, ["/transactions/tickets/quote"], {
+    method: "POST",
+    config: {
+      tags: ["api"],
+      description: `Used to preview the result of a ticket payment
   `,
-        notes: `Payload must have an array \`trips\`, each an object with a \`tripId\`, \`boardStopId\` and \`alightStopId\`.
+      notes: `Payload must have an array \`trips\`, each an object with a \`tripId\`, \`boardStopId\` and \`alightStopId\`.
   `,
-        validate: {
-          payload: Joi.object({
-            trips: Joi.array().items(
-              Joi.object({
-                tripId: Joi.number().integer(),
-                boardStopId: Joi.number().integer(),
-                alightStopId: Joi.number().integer(),
-              })
-            ),
-            applyRoutePass: Joi.boolean().default(false),
-            applyReferralCredits: Joi.boolean().default(false),
-            applyCredits: Joi.boolean().default(false),
-            promoCode: Joi.object()
-              .keys({
-                code: Joi.string().allow(""),
-                options: Joi.object(),
-              })
-              .allow(null)
-              .default(null),
-            groupItemsByType: Joi.boolean().default(false),
-          }).unknown(),
-        },
+      validate: {
+        payload: Joi.object({
+          trips: Joi.array().items(
+            Joi.object({
+              tripId: Joi.number().integer(),
+              boardStopId: Joi.number().integer(),
+              alightStopId: Joi.number().integer(),
+            })
+          ),
+          applyRoutePass: Joi.boolean().default(false),
+          applyReferralCredits: Joi.boolean().default(false),
+          applyCredits: Joi.boolean().default(false),
+          promoCode: Joi.object()
+            .keys({
+              code: Joi.string().allow(""),
+              options: Joi.object(),
+            })
+            .allow(null)
+            .default(null),
+          groupItemsByType: Joi.boolean().default(false),
+        }).unknown(),
       },
+    },
 
-      async handler(request, reply) {
-        try {
-          for (let trip of request.payload.trips) {
-            trip.userId = request.auth.credentials.userId || 0
-          }
-
-          let db = getDB(request)
-          let m = getModels(request)
-          let [preparedTransaction] = await prepareTicketSale([db, m], {
-            trips: request.payload.trips,
-            promoCode: request.payload.promoCode,
-            applyRoutePass: request.payload.applyRoutePass,
-            applyReferralCredits: request.payload.applyReferralCredits,
-            applyCredits: request.payload.applyCredits,
-            dryRun: true,
-          })
-
-          const groupItemsByType = preparedTransaction => {
-            const groupedItems = _.groupBy(
-              preparedTransaction.transactionItems,
-              "itemType"
-            )
-            return {
-              ...preparedTransaction,
-              transactionItems: groupedItems,
-              totals: _(groupedItems)
-                .mapValues(items =>
-                  _(["credit", "debit"])
-                    .map(field => [
-                      field,
-                      _.sumBy(items, item => parseFloat(item[field])),
-                    ])
-                    .fromPairs()
-                    .value()
-                )
-                .value(),
-            }
-          }
-          reply(
-            request.payload.groupItemsByType
-              ? groupItemsByType(preparedTransaction)
-              : preparedTransaction
-          )
-        } catch (err) {
-          defaultErrorHandler(reply)(err)
+    async handler(request, reply) {
+      try {
+        for (let trip of request.payload.trips) {
+          trip.userId = request.auth.credentials.userId || 0
         }
-      },
-    }
-  )
+
+        let db = getDB(request)
+        let m = getModels(request)
+        let [preparedTransaction] = await prepareTicketSale([db, m], {
+          trips: request.payload.trips,
+          promoCode: request.payload.promoCode,
+          applyRoutePass: request.payload.applyRoutePass,
+          applyReferralCredits: request.payload.applyReferralCredits,
+          applyCredits: request.payload.applyCredits,
+          dryRun: true,
+        })
+
+        const groupItemsByType = preparedTransaction => {
+          const groupedItems = _.groupBy(
+            preparedTransaction.transactionItems,
+            "itemType"
+          )
+          return {
+            ...preparedTransaction,
+            transactionItems: groupedItems,
+            totals: _(groupedItems)
+              .mapValues(items =>
+                _(["credit", "debit"])
+                  .map(field => [
+                    field,
+                    _.sumBy(items, item => parseFloat(item[field])),
+                  ])
+                  .fromPairs()
+                  .value()
+              )
+              .value(),
+          }
+        }
+        reply(
+          request.payload.groupItemsByType
+            ? groupItemsByType(preparedTransaction)
+            : preparedTransaction
+        )
+      } catch (err) {
+        defaultErrorHandler(reply)(err)
+      }
+    },
+  })
 
   const refundViaStripeWithAccounting = async (
     { db, txn, undoFn, stripeRefundInfo },

--- a/src/lib/endpoints/transactions.js
+++ b/src/lib/endpoints/transactions.js
@@ -54,7 +54,7 @@ const INVALID_CREDIT_TAGS = [
 export const register = (server, options, next) => {
   routeRequestsTo(
     server,
-    ["/transactions/payment_ticket_sale", "/transactions/tickets/payment"],
+    ["/transactions/tickets/payment"],
     {
       method: "POST",
       config: {
@@ -394,7 +394,7 @@ export const register = (server, options, next) => {
 
   routeRequestsTo(
     server,
-    ["/transactions/ticket_sale", "/transactions/tickets/quote"],
+    ["/transactions/tickets/quote"],
     {
       method: "POST",
       config: {

--- a/src/lib/transactions/index.js
+++ b/src/lib/transactions/index.js
@@ -104,10 +104,6 @@ export async function prepareTicketSale(connection, optionsRaw) {
       .allow(null)
       .default(null),
 
-    creditTag: Joi.string()
-      .allow(null)
-      .optional(),
-
     dryRun: Joi.boolean().default(false),
     applyRoutePass: Joi.boolean().default(false),
     applyReferralCredits: Joi.boolean().default(false),
@@ -179,16 +175,12 @@ export async function prepareTicketSale(connection, optionsRaw) {
         // 2. Sanity checks on input
         runOrderChecks(transactionBuilder, options.checks)
 
-        if (options.applyRoutePass || options.creditTag) {
-          const routePassTags = options.creditTag
-            ? [options.creditTag]
-            : options.applyRoutePass
-              ? await routePassTagsFrom(
-                  transactionBuilder.items,
-                  transactionBuilder.models,
-                  transactionBuilder.transaction
-                )
-              : []
+        if (options.applyRoutePass) {
+          const routePassTags = await routePassTagsFrom(
+            transactionBuilder.items,
+            transactionBuilder.models,
+            transactionBuilder.transaction
+          )
           // If both crowdstart over rp tags are present on a route,
           // crowdstart will discount first through alphabetical order
           for (const tag of routePassTags) {

--- a/src/lib/util/endpoints.js
+++ b/src/lib/util/endpoints.js
@@ -9,8 +9,9 @@ const auth = require("../core/auth")
  * Routes requests to a HAPI server to the specified
  * HAPI route configuration object over multiple RESTful paths
  * @param {Server} server - a HAPI server object
- * @param {Object} config - a route configuration object
  * @param {...(string|object)} paths - one or more strings or
+ * @param {Object} config - a route configuration object
+ * @return {undefined}
  * partial route configuration objects which contains at least
  * a path field that would be merged into a copy of config
  * @example
@@ -28,7 +29,7 @@ const auth = require("../core/auth")
  *           payload: Joi.object({
  *             ticketId: Joi.number().integer().min(0).required(),
  *             targetAmt: Joi.number().min(0).required(),
- *             creditTag: Joi.string().disallow(INVALID_CREDIT_TAGS).required()
+ *             tag: Joi.string().disallow(INVALID_CREDIT_TAGS).required()
  *           })
  *         }
  *       }
@@ -42,7 +43,7 @@ const auth = require("../core/auth")
  *           },
  *           payload: Joi.object({
  *             targetAmt: Joi.number().min(0).required(),
- *             creditTag: Joi.string().disallow(INVALID_CREDIT_TAGS).required()
+ *             tag: Joi.string().disallow(INVALID_CREDIT_TAGS).required()
  *           })
  *         }
  *       }
@@ -62,6 +63,7 @@ export const routeRequestsTo = (server, paths, config) => paths.forEach(path => 
  * Wraps an array of callbacks into a HAPI handler.
  * @param {...function} callbacks - functions that, when chained together,
  * will produce an object that is accepted by HAPI's reply callback
+ * @return {function} a request handler for HAPI
  * @example <caption>Using makeHandlerCallbackAdapter in HAPI routes</caption>
  *   // Define a function that looks up an instance for a given request
  *   const findContactListById = async (request) => {

--- a/src/lib/util/endpoints.js
+++ b/src/lib/util/endpoints.js
@@ -2,7 +2,12 @@ const Boom = require("boom")
 const _ = require("lodash")
 const assert = require("assert")
 
-const {NotFoundError, defaultErrorHandler, getDB, getModels} = require("../util/common")
+const {
+  NotFoundError,
+  defaultErrorHandler,
+  getDB,
+  getModels,
+} = require("../util/common")
 const auth = require("../core/auth")
 
 /**
@@ -55,9 +60,12 @@ const auth = require("../core/auth")
  *    handler: ...
  *  });
  */
-export const routeRequestsTo = (server, paths, config) => paths.forEach(path => {
-  server.route(_.merge({}, config, typeof path === 'string' ? { path } : path))
-})
+export const routeRequestsTo = (server, paths, config) =>
+  paths.forEach(path => {
+    server.route(
+      _.merge({}, config, typeof path === "string" ? { path } : path)
+    )
+  })
 
 /**
  * Wraps an array of callbacks into a HAPI handler.
@@ -108,34 +116,64 @@ export const routeRequestsTo = (server, paths, config) => paths.forEach(path => 
  */
 export const handleRequestWith = (...callbacks) => async (request, reply) => {
   const context = { db: getDB(request), models: getModels(request) }
-  return reply(Promise
-    .resolve(reduceCallbacksWith(request, request, context, callbacks))
-    .catch(defaultErrorHandler(response => response))
+  return reply(
+    Promise.resolve(
+      reduceCallbacksWith(request, request, context, callbacks)
+    ).catch(defaultErrorHandler(response => response))
   )
 }
 
-export const inSingleDBTransaction = (...callbacks) => (current, request, context) =>
-  context.db.transaction(transaction => reduceCallbacksWith(current, request, {...context, transaction}, callbacks))
+export const inSingleDBTransaction = (...callbacks) => (
+  current,
+  request,
+  context
+) =>
+  context.db.transaction(transaction =>
+    reduceCallbacksWith(
+      current,
+      request,
+      { ...context, transaction },
+      callbacks
+    )
+  )
 
-const reduceCallbacksWith = (initial, request, context, callbacks) => callbacks.reduce(
-  (current, callback) => current.then(val => callback(val, request, context)),
-  Promise.resolve(initial)
-)
+const reduceCallbacksWith = (initial, request, context, callbacks) =>
+  callbacks.reduce(
+    (current, callback) => current.then(val => callback(val, request, context)),
+    Promise.resolve(initial)
+  )
 
-export const authorizeByRole = (role, lookupId = (passthrough, request) => request.params.id) =>
-  (passthrough, request) => {
-    auth.assertAdminRole(request.auth.credentials, role, lookupId(passthrough, request))
-    return passthrough
-  }
-
-export const instToJSONOrNotFound = inst => inst ? inst.toJSON() : Boom.notFound()
-
-export const assertThat = (f, ErrorType, msg) => {
-  assert(Error.prototype.isPrototypeOf(new ErrorType()) && typeof ErrorType.assert === 'function')
-  return inst => { ErrorType.assert(f(inst), msg); return inst }
+export const authorizeByRole = (
+  role,
+  lookupId = (passthrough, request) => request.params.id
+) => (passthrough, request) => {
+  auth.assertAdminRole(
+    request.auth.credentials,
+    role,
+    lookupId(passthrough, request)
+  )
+  return passthrough
 }
 
-export const assertFound = assertThat(inst => inst, NotFoundError, 'Item not found')
+export const instToJSONOrNotFound = inst =>
+  inst ? inst.toJSON() : Boom.notFound()
+
+export const assertThat = (f, ErrorType, msg) => {
+  assert(
+    Error.prototype.isPrototypeOf(new ErrorType()) &&
+      typeof ErrorType.assert === "function"
+  )
+  return inst => {
+    ErrorType.assert(f(inst), msg)
+    return inst
+  }
+}
+
+export const assertFound = assertThat(
+  inst => inst,
+  NotFoundError,
+  "Item not found"
+)
 
 export const deleteInst = async inst => {
   if (inst) {

--- a/test/creditsIntegration.js
+++ b/test/creditsIntegration.js
@@ -235,7 +235,7 @@ lab.experiment("Credits integration test", function () {
         trips: poItems1,
         stripeToken: await createStripeToken(),
         applyCredits: true,
-        creditTag: testTag,
+        applyRoutePass: true,
         promoCode: { code: promoCode, options: {} },
       },
       headers: authHeaders.user,

--- a/test/discountedRoutePassPurchases.js
+++ b/test/discountedRoutePassPurchases.js
@@ -13,14 +13,14 @@ const stripe = Payment.stripe
 const {models} = require("../src/lib/core/dbschema")()
 
 lab.experiment("Integration with route pass transaction", function () {
-  var userInstance
-  var authHeaders = {}
+  let userInstance
+  let authHeaders = {}
 
-  var companyInstance
-  var routeInstance
-  var customerInfo
-  var stopInstances = []
-  var tripInstances = []
+  let companyInstance
+  let routeInstance
+  let customerInfo
+  let stopInstances = []
+  let tripInstances = []
 
   lab.beforeEach(() => models.RoutePass.destroy({ truncate: true }))
   lab.afterEach(async () => resetTripInstances(models, tripInstances))
@@ -29,21 +29,21 @@ lab.experiment("Integration with route pass transaction", function () {
     ({userInstance, companyInstance, tripInstances, stopInstances, routeInstance} =
       await testData.createUsersCompaniesRoutesAndTrips(models))
 
-    var userToken = userInstance.makeToken()
+    let userToken = userInstance.makeToken()
     authHeaders.user = {authorization: "Bearer " + userToken}
 
     const stripeToken = await createStripeToken()
     const c = await stripe.customers.create({
       source: stripeToken,
       metadata: {
-        userId: userInstance.id
-      }
+        userId: userInstance.id,
+      },
     })
     customerInfo = await stripe.customers.retrieve(c.id)
 
-    var adminToken = (await loginAs("admin", {
+    let adminToken = (await loginAs("admin", {
       transportCompanyId: companyInstance.id,
-      permissions: ['refund']
+      permissions: ['refund'],
     })).result.sessionToken
     authHeaders.admin = {authorization: "Bearer " + adminToken}
 
@@ -55,20 +55,20 @@ lab.experiment("Integration with route pass transaction", function () {
         "description": "For test",
         "tag": "TESTTAG",
         "qualifyingCriteria": [{
-          "type": "noLimit"
+          "type": "noLimit",
         }],
         "discountFunction": {
           "type": "simpleRate",
-          "params": {"rate": 0.1}
+          "params": {"rate": 0.1},
         },
         "refundFunction": {
-          "type": "refundDiscountedAmt"
+          "type": "refundDiscountedAmt",
         },
         "usageLimit": {
           "userLimit": null,
-          "globalLimit": null
-        }
-      }
+          "globalLimit": null,
+        },
+      },
     })
     await routeInstance.update({ tags: ['public', promotion.params.tag] })
     await Promise.all(tripInstances.map(t => t.update({ price: '5' })))
@@ -96,10 +96,10 @@ lab.experiment("Integration with route pass transaction", function () {
         sourceId: customerInfo.sources.data[0].id,
         promoCode: {
           code: 'TEST PROMO',
-          options: {}
+          options: {},
         },
       },
-      headers: authHeaders.user
+      headers: authHeaders.user,
     })
     expect(saleResponse.statusCode).to.equal(200)
 
@@ -120,20 +120,20 @@ lab.experiment("Integration with route pass transaction", function () {
         "description": "Bad promo",
         "tag": "TESTTAG",
         "qualifyingCriteria": [{
-          "type": "noLimit"
+          "type": "noLimit",
         }],
         "discountFunction": {
           "type": "simpleRate",
-          "params": {"rate": 0.1}
+          "params": {"rate": 0.1},
         },
         "refundFunction": {
-          "type": "refundDiscountedAmt"
+          "type": "refundDiscountedAmt",
         },
         "usageLimit": {
           "userLimit": null,
-          "globalLimit": null
-        }
-      }
+          "globalLimit": null,
+        },
+      },
     })
     const saleResponse = await server.inject({
       method: "POST",
@@ -147,10 +147,10 @@ lab.experiment("Integration with route pass transaction", function () {
         sourceId: customerInfo.sources.data[0].id,
         promoCode: {
           code: 'TEST PROMO',
-          options: {}
+          options: {},
         },
       },
-      headers: authHeaders.user
+      headers: authHeaders.user,
     })
     expect(saleResponse.statusCode).to.equal(400)
     await cleanlyDeletePromotions({code: 'TEST PROMO'})
@@ -168,7 +168,7 @@ lab.experiment("Integration with route pass transaction", function () {
       sourceId: customerInfo.sources.data[0].id,
       promoCode: {
         code: '',
-        options: {}
+        options: {},
       },
     }
 
@@ -177,8 +177,8 @@ lab.experiment("Integration with route pass transaction", function () {
       url: "/transactions/route_passes/payment",
       payload,
       headers: {
-        authorization: `Bearer ${userInstance.makeToken()}`
-      }
+        authorization: `Bearer ${userInstance.makeToken()}`,
+      },
     })
 
     expect(saleResponse.statusCode).equal(200)
@@ -202,20 +202,20 @@ lab.experiment("Integration with route pass transaction", function () {
         "description": "Bad promo",
         "tag": "TESTTAG",
         "qualifyingCriteria": [{
-          "type": "noLimit"
+          "type": "noLimit",
         }],
         "discountFunction": {
           "type": "simpleRate",
-          "params": {"rate": 0.1}
+          "params": {"rate": 0.1},
         },
         "refundFunction": {
-          "type": "refundDiscountedAmt"
+          "type": "refundDiscountedAmt",
         },
         "usageLimit": {
           "userLimit": null,
-          "globalLimit": null
-        }
-      }
+          "globalLimit": null,
+        },
+      },
     })
 
     await models.Promotion.create({
@@ -225,20 +225,20 @@ lab.experiment("Integration with route pass transaction", function () {
         "description": "Better promo",
         "tag": "TESTTAG",
         "qualifyingCriteria": [{
-          "type": "noLimit"
+          "type": "noLimit",
         }],
         "discountFunction": {
           "type": "simpleRate",
-          "params": {"rate": 0.2}
+          "params": {"rate": 0.2},
         },
         "refundFunction": {
-          "type": "refundDiscountedAmt"
+          "type": "refundDiscountedAmt",
         },
         "usageLimit": {
           "userLimit": null,
-          "globalLimit": null
-        }
-      }
+          "globalLimit": null,
+        },
+      },
     })
 
     const payload = {
@@ -250,7 +250,7 @@ lab.experiment("Integration with route pass transaction", function () {
       sourceId: customerInfo.sources.data[0].id,
       promoCode: {
         code: '',
-        options: {}
+        options: {},
       },
     }
 
@@ -259,8 +259,8 @@ lab.experiment("Integration with route pass transaction", function () {
       url: "/transactions/route_passes/payment",
       payload,
       headers: {
-        authorization: `Bearer ${userInstance.makeToken()}`
-      }
+        authorization: `Bearer ${userInstance.makeToken()}`,
+      },
     })
     expect(saleResponse.statusCode).to.equal(200)
 
@@ -281,20 +281,20 @@ lab.experiment("Integration with route pass transaction", function () {
         "description": "Better promo",
         "tag": "TESTTAG",
         "qualifyingCriteria": [{
-          "type": "noLimit"
+          "type": "noLimit",
         }],
         "discountFunction": {
           "type": "simpleRate",
-          "params": {"rate": 0.2}
+          "params": {"rate": 0.2},
         },
         "refundFunction": {
-          "type": "refundDiscountedAmt"
+          "type": "refundDiscountedAmt",
         },
         "usageLimit": {
           "userLimit": null,
-          "globalLimit": null
-        }
-      }
+          "globalLimit": null,
+        },
+      },
     })
 
     const creditTag = 'rp-1337'
@@ -309,7 +309,7 @@ lab.experiment("Integration with route pass transaction", function () {
       sourceId: customerInfo.sources.data[0].id,
       promoCode: {
         code: '',
-        options: {}
+        options: {},
       },
     }
 
@@ -318,8 +318,8 @@ lab.experiment("Integration with route pass transaction", function () {
       url: "/transactions/route_passes/payment",
       payload,
       headers: {
-        authorization: `Bearer ${userInstance.makeToken()}`
-      }
+        authorization: `Bearer ${userInstance.makeToken()}`,
+      },
     })
     expect(saleResponse.statusCode).to.equal(200)
 
@@ -330,7 +330,7 @@ lab.experiment("Integration with route pass transaction", function () {
     expect(saleResponse.result.description).include(items.discount[0].debit)
 
     const routePasses = await models.RoutePass.findAll({
-      where: { userId: userInstance.id, companyId: companyInstance.id, tag: creditTag }
+      where: { userId: userInstance.id, companyId: companyInstance.id, tag: creditTag },
     })
     expect(routePasses.length).equal(10)
   })
@@ -345,25 +345,25 @@ lab.experiment("Integration with route pass transaction", function () {
         "description": "Better promo",
         "tag": "TESTTAG",
         "qualifyingCriteria": [{
-          "type": "noLimit"
+          "type": "noLimit",
         }],
         "discountFunction": {
           "type": "tieredRateByTotalValue",
           "params": {
             "schedule": [
               [50, 0.2],
-              [100, 0.4]
-            ]
-          }
+              [100, 0.4],
+            ],
+          },
         },
         "refundFunction": {
-          "type": "refundDiscountedAmt"
+          "type": "refundDiscountedAmt",
         },
         "usageLimit": {
           "userLimit": null,
-          "globalLimit": null
-        }
-      }
+          "globalLimit": null,
+        },
+      },
     })
 
     const creditTag = 'TESTTAG'
@@ -378,7 +378,7 @@ lab.experiment("Integration with route pass transaction", function () {
       sourceId: customerInfo.sources.data[0].id,
       promoCode: {
         code: '',
-        options: {}
+        options: {},
       },
     }
 
@@ -387,8 +387,8 @@ lab.experiment("Integration with route pass transaction", function () {
       url: "/transactions/route_passes/payment",
       payload,
       headers: {
-        authorization: `Bearer ${userInstance.makeToken()}`
-      }
+        authorization: `Bearer ${userInstance.makeToken()}`,
+      },
     })
     expect(saleResponse.statusCode).to.equal(200)
 
@@ -405,8 +405,8 @@ lab.experiment("Integration with route pass transaction", function () {
       url: "/transactions/route_passes/payment",
       payload,
       headers: {
-        authorization: `Bearer ${userInstance.makeToken()}`
-      }
+        authorization: `Bearer ${userInstance.makeToken()}`,
+      },
     })
     expect(saleResponse2.statusCode).to.equal(200)
 
@@ -417,7 +417,7 @@ lab.experiment("Integration with route pass transaction", function () {
     expect(saleResponse2.result.description).include(items.discount[0].debit)
 
     const routePasses = await models.RoutePass.findAll({
-      where: { userId: userInstance.id, companyId: companyInstance.id, tag: creditTag }
+      where: { userId: userInstance.id, companyId: companyInstance.id, tag: creditTag },
     })
     expect(routePasses.length).equal(30)
   })
@@ -428,7 +428,7 @@ lab.experiment("Integration with route pass transaction", function () {
     const contactListInstance = await models.ContactList.create({
       transportCompanyId: routeInstance.transportCompanyId,
       telephones: [userInstance.telephone],
-      emails: []
+      emails: [],
     })
 
     await models.Promotion.create({
@@ -439,25 +439,25 @@ lab.experiment("Integration with route pass transaction", function () {
         "tag": "TESTTAG",
         "qualifyingCriteria": [{
           "type": "limitByContactList",
-          "params": { "contactListId": contactListInstance.id }
+          "params": { "contactListId": contactListInstance.id },
         }],
         "discountFunction": {
           "type": "tieredRateByTotalValue",
           "params": {
             "schedule": [
               [50, 0.2],
-              [100, 0.4]
-            ]
-          }
+              [100, 0.4],
+            ],
+          },
         },
         "refundFunction": {
-          "type": "refundDiscountedAmt"
+          "type": "refundDiscountedAmt",
         },
         "usageLimit": {
           "userLimit": null,
-          "globalLimit": null
-        }
-      }
+          "globalLimit": null,
+        },
+      },
     })
 
     const creditTag = 'TESTTAG'
@@ -472,7 +472,7 @@ lab.experiment("Integration with route pass transaction", function () {
       sourceId: customerInfo.sources.data[0].id,
       promoCode: {
         code: '',
-        options: {}
+        options: {},
       },
     }
 
@@ -481,8 +481,8 @@ lab.experiment("Integration with route pass transaction", function () {
       url: "/transactions/route_passes/payment",
       payload,
       headers: {
-        authorization: `Bearer ${userInstance.makeToken()}`
-      }
+        authorization: `Bearer ${userInstance.makeToken()}`,
+      },
     })
     expect(saleResponse.statusCode).to.equal(200)
 
@@ -499,8 +499,8 @@ lab.experiment("Integration with route pass transaction", function () {
       url: "/transactions/route_passes/payment",
       payload,
       headers: {
-        authorization: `Bearer ${userInstance.makeToken()}`
-      }
+        authorization: `Bearer ${userInstance.makeToken()}`,
+      },
     })
     expect(saleResponse2.statusCode).to.equal(200)
 
@@ -511,7 +511,7 @@ lab.experiment("Integration with route pass transaction", function () {
     expect(saleResponse2.result.description).include(items.discount[0].debit)
 
     const routePasses = await models.RoutePass.findAll({
-      where: { userId: userInstance.id, companyId: companyInstance.id, tag: creditTag }
+      where: { userId: userInstance.id, companyId: companyInstance.id, tag: creditTag },
     })
     expect(routePasses.length).equal(30)
   })

--- a/test/discountedRoutePassPurchases.js
+++ b/test/discountedRoutePassPurchases.js
@@ -89,7 +89,7 @@ lab.experiment("Integration with route pass transaction", function () {
       url: "/transactions/route_passes/payment",
       payload: {
         value: 50,
-        creditTag: 'TESTTAG',
+        tag: 'TESTTAG',
         companyId: companyInstance.id,
 
         customerId: customerInfo.id,
@@ -140,7 +140,7 @@ lab.experiment("Integration with route pass transaction", function () {
       url: "/transactions/route_passes/payment",
       payload: {
         value: 50,
-        creditTag: 'TESTTAG',
+        tag: 'TESTTAG',
         companyId: companyInstance.id,
         expectedPrice: 46,
         customerId: customerInfo.id,
@@ -161,7 +161,7 @@ lab.experiment("Integration with route pass transaction", function () {
 
     const payload = {
       value: 50,
-      creditTag: 'TESTTAG',
+      tag: 'TESTTAG',
       companyId: companyInstance.id,
 
       customerId: customerInfo.id,
@@ -243,7 +243,7 @@ lab.experiment("Integration with route pass transaction", function () {
 
     const payload = {
       value: 50,
-      creditTag: 'TESTTAG',
+      tag: 'TESTTAG',
       companyId: companyInstance.id,
 
       customerId: customerInfo.id,
@@ -297,12 +297,12 @@ lab.experiment("Integration with route pass transaction", function () {
       },
     })
 
-    const creditTag = 'rp-1337'
-    await routeInstance.update({ tags: ['TESTTAG', creditTag] })
+    const tag = 'rp-1337'
+    await routeInstance.update({ tags: ['TESTTAG', tag] })
 
     const payload = {
       value: 50,
-      creditTag,
+      tag,
       companyId: companyInstance.id,
 
       customerId: customerInfo.id,
@@ -330,7 +330,7 @@ lab.experiment("Integration with route pass transaction", function () {
     expect(saleResponse.result.description).include(items.discount[0].debit)
 
     const routePasses = await models.RoutePass.findAll({
-      where: { userId: userInstance.id, companyId: companyInstance.id, tag: creditTag },
+      where: { userId: userInstance.id, companyId: companyInstance.id, tag },
     })
     expect(routePasses.length).equal(10)
   })
@@ -366,12 +366,12 @@ lab.experiment("Integration with route pass transaction", function () {
       },
     })
 
-    const creditTag = 'TESTTAG'
-    await routeInstance.update({ tags: [creditTag] })
+    const tag = 'TESTTAG'
+    await routeInstance.update({ tags: [tag] })
 
     const payload = {
       value: 50,
-      creditTag,
+      tag,
       companyId: companyInstance.id,
 
       customerId: customerInfo.id,
@@ -417,7 +417,7 @@ lab.experiment("Integration with route pass transaction", function () {
     expect(saleResponse2.result.description).include(items.discount[0].debit)
 
     const routePasses = await models.RoutePass.findAll({
-      where: { userId: userInstance.id, companyId: companyInstance.id, tag: creditTag },
+      where: { userId: userInstance.id, companyId: companyInstance.id, tag },
     })
     expect(routePasses.length).equal(30)
   })
@@ -460,12 +460,12 @@ lab.experiment("Integration with route pass transaction", function () {
       },
     })
 
-    const creditTag = 'TESTTAG'
-    await routeInstance.update({ tags: [creditTag] })
+    const tag = 'TESTTAG'
+    await routeInstance.update({ tags: [tag] })
 
     const payload = {
       value: 50,
-      creditTag,
+      tag,
       companyId: companyInstance.id,
 
       customerId: customerInfo.id,
@@ -511,7 +511,7 @@ lab.experiment("Integration with route pass transaction", function () {
     expect(saleResponse2.result.description).include(items.discount[0].debit)
 
     const routePasses = await models.RoutePass.findAll({
-      where: { userId: userInstance.id, companyId: companyInstance.id, tag: creditTag },
+      where: { userId: userInstance.id, companyId: companyInstance.id, tag },
     })
     expect(routePasses.length).equal(30)
   })

--- a/test/eventSubscriptions.js
+++ b/test/eventSubscriptions.js
@@ -259,7 +259,7 @@ lab.experiment("Event subscriptions", function () {
     // Make a transaction that will fail
     await server.inject({
       method: 'POST',
-      url: '/transactions/payment_ticket_sale',
+      url: '/transactions/tickets/payment',
       payload: {
         trips: [
           {tripId: 1999,

--- a/test/eventSubscriptions.js
+++ b/test/eventSubscriptions.js
@@ -9,31 +9,32 @@ import eventFormatters from '../src/lib/events/formatters'
 import * as eventHandlers from '../src/lib/events/handlers'
 import * as events from '../src/lib/events/events'
 
-export var lab = Lab.script()
+export const lab = Lab.script()
 
 lab.experiment("Event subscriptions", function () {
-  var adminInst, companyInst
-  var lastMessage
+  let adminInst
+  let companyInst
+  let lastMessage
 
   lab.before({timeout: 10000}, async function () {
     eventDefinitions['testEvent'] = {
       schema: Joi.object({
-        num: Joi.number().required()
-      }).unknown()
+        num: Joi.number().required(),
+      }).unknown(),
     }
 
     eventDefinitions['testEventWithParams'] = {
       schema: Joi.object({
-        num: Joi.number().required()
+        num: Joi.number().required(),
       }).unknown(),
 
       params: Joi.object({
-        string: Joi.string().required()
+        string: Joi.string().required(),
       }),
 
       filter (params, data) {
         return parseInt(params.string) === data.num
-      }
+      },
     }
 
     eventFormatters['testEvent'] = {
@@ -52,13 +53,13 @@ lab.experiment("Event subscriptions", function () {
       },
       '1' (event) {
         return {
-          message: `Second is ${event.num}`
+          message: `Second is ${event.num}`,
         }
       },
     }
     adminInst = await m.Admin.create({
       email: 'test@example.com',
-      telephone: '+6581001860'
+      telephone: '+6581001860',
     })
     companyInst = await m.TransportCompany.create({})
 
@@ -84,29 +85,29 @@ lab.experiment("Event subscriptions", function () {
       where: {
         agent: {
           telephone: adminInst.telephone,
-          email: adminInst.email
-        }
-      }
+          email: adminInst.email,
+        },
+      },
     })
   })
 
   lab.test('Subscriptions are properly validated', async function () {
-    var createResult = await server.inject({
+    let createResult = await server.inject({
       method: 'POST',
       url: `/companies/${companyInst.id}/eventSubscriptions`,
       payload: {
         agent: {
           telephone: adminInst.telephone,
-          email: adminInst.email
+          email: adminInst.email,
         },
         event: 'testEventWithParams',
         formatter: '0',
         params: {invalidParams: true},
-        handler: 'test'
+        handler: 'test',
       },
       headers: {
-        authorization: `Bearer ${adminInst.makeToken()}`
-      }
+        authorization: `Bearer ${adminInst.makeToken()}`,
+      },
     })
     /* 500 because we don't have a reference to Joi.ValidationError and
     so we cannot trap it :( */
@@ -118,39 +119,39 @@ lab.experiment("Event subscriptions", function () {
       payload: {
         agent: {
           telephone: adminInst.telephone,
-          email: adminInst.email
+          email: adminInst.email,
         },
         event: 'testEventWithParams',
         formatter: '0',
         params: {string: '123'},
-        handler: 'test'
+        handler: 'test',
       },
       headers: {
-        authorization: `Bearer ${adminInst.makeToken()}`
-      }
+        authorization: `Bearer ${adminInst.makeToken()}`,
+      },
     })
     expect(createResult.statusCode).equal(200)
   })
 
   lab.test('Subscriptions are properly loaded', {timeout: 10000}, async function () {
-    var createResult = await server.inject({
+    let createResult = await server.inject({
       method: 'POST',
       url: `/companies/${companyInst.id}/eventSubscriptions`,
       payload: {
         agent: {
           telephone: adminInst.telephone,
-          email: adminInst.email
+          email: adminInst.email,
         },
         event: 'testEvent',
         formatter: '0',
         params: null,
-        handler: 'test'
+        handler: 'test',
       },
       headers: {
-        authorization: `Bearer ${adminInst.makeToken()}`
-      }
+        authorization: `Bearer ${adminInst.makeToken()}`,
+      },
     })
-    var subscriptionId = createResult.result.id
+    let subscriptionId = createResult.result.id
 
     // the reload is not synchronous, so let it wait...
     await new Promise((resolve) => setTimeout(resolve, 500))
@@ -166,16 +167,16 @@ lab.experiment("Event subscriptions", function () {
       payload: {
         agent: {
           telephone: adminInst.telephone,
-          email: adminInst.email
+          email: adminInst.email,
         },
         event: 'testEvent',
         formatter: '1',
         params: null,
-        handler: 'test'
+        handler: 'test',
       },
       headers: {
-        authorization: `Bearer ${adminInst.makeToken()}`
-      }
+        authorization: `Bearer ${adminInst.makeToken()}`,
+      },
     })
 
     // the reload is not synchronous, so let it wait...
@@ -190,8 +191,8 @@ lab.experiment("Event subscriptions", function () {
       method: 'DELETE',
       url: `/companies/${companyInst.id}/eventSubscriptions/${subscriptionId}`,
       headers: {
-        authorization: `Bearer ${adminInst.makeToken()}`
-      }
+        authorization: `Bearer ${adminInst.makeToken()}`,
+      },
     })
 
     // the reload is not synchronous, so let it wait...
@@ -205,12 +206,12 @@ lab.experiment("Event subscriptions", function () {
     await m.EventSubscription.create({
       agent: {
         telephone: adminInst.telephone,
-        email: adminInst.email
+        email: adminInst.email,
       },
       event: 'testEvent',
       formatter: '1',
       params: null,
-      handler: 'test'
+      handler: 'test',
     })
 
     await server.plugins['daemon-event-subscriptions'].reloadSubscriptions()
@@ -224,12 +225,12 @@ lab.experiment("Event subscriptions", function () {
     await m.EventSubscription.create({
       agent: {
         telephone: adminInst.telephone,
-        email: adminInst.email
+        email: adminInst.email,
       },
       event: 'testEventWithParams',
       formatter: '0',
       params: {string: '12'},
-      handler: 'test'
+      handler: 'test',
     })
 
     await server.plugins['daemon-event-subscriptions'].reloadSubscriptions()
@@ -243,16 +244,16 @@ lab.experiment("Event subscriptions", function () {
   })
 
   lab.test('Transaction failure event', {timeout: 10000}, async function () {
-    var userInst = await m.User.create({})
+    let userInst = await m.User.create({})
     await m.EventSubscription.create({
       agent: {
         telephone: adminInst.telephone,
-        email: adminInst.email
+        email: adminInst.email,
       },
       event: 'transactionFailure',
       formatter: '0',
       params: {string: '12'},
-      handler: 'test'
+      handler: 'test',
     })
     await server.plugins['daemon-event-subscriptions'].reloadSubscriptions()
 
@@ -264,13 +265,13 @@ lab.experiment("Event subscriptions", function () {
         trips: [
           {tripId: 1999,
             boardStopId: 22,
-            alightStopId: 22}
+            alightStopId: 22},
         ],
-        stripeToken: 'fake token'
+        stripeToken: 'fake token',
       },
       headers: {
-        authorization: `Bearer ${userInst.makeToken()}`
-      }
+        authorization: `Bearer ${userInst.makeToken()}`,
+      },
     })
 
     // Failure should be in message
@@ -280,42 +281,42 @@ lab.experiment("Event subscriptions", function () {
 
   lab.test('Trip cancellation event', {timeout: 10000}, async function () {
     // Some trip data
-    var a = await m.Admin.create({
+    let a = await m.Admin.create({
       email: 'test@asdfasdfasdfexample.com',
-      telephone: '+6599999999'
+      telephone: '+6599999999',
     })
-    var c = await m.TransportCompany.create({
-      name: 'Required for some reason'
+    let c = await m.TransportCompany.create({
+      name: 'Required for some reason',
     })
 
     await a.addTransportCompany(c, {permissions: ['manage-notifications', 'update-trip-status']})
 
-    var routeInst = await m.Route.create({
+    let routeInst = await m.Route.create({
       transportCompanyId: c.id,
     })
-    var stopInst = await m.Stop.create({
-      coordinates: {type: 'Point', coordinates: randomSingaporeLngLat()}
+    let stopInst = await m.Stop.create({
+      coordinates: {type: 'Point', coordinates: randomSingaporeLngLat()},
     })
-    var tripInst = await m.Trip.create({
+    let tripInst = await m.Trip.create({
       routeId: routeInst.id,
       tripStops: [
         {stopId: stopInst.id, time: '2016-01-01T00:00:00', canBoard: true, canAlight: true},
         {stopId: stopInst.id, time: '2016-01-01T04:00:00', canBoard: true, canAlight: true},
-      ]
+      ],
     }, {include: [m.TripStop]})
     const headers = {
-      authorization: `Bearer ${a.makeToken()}`
+      authorization: `Bearer ${a.makeToken()}`,
     }
       // Some event data
     await m.EventSubscription.create({
       agent: {
         telephone: adminInst.telephone,
-        email: adminInst.email
+        email: adminInst.email,
       },
       event: 'tripCancelled',
       formatter: '0',
       params: {routeIds: [routeInst.id], ignoreIfEmpty: false},
-      handler: 'test'
+      handler: 'test',
     })
     await server.plugins['daemon-event-subscriptions'].reloadSubscriptions()
     // Execute the cancellation
@@ -323,9 +324,9 @@ lab.experiment("Event subscriptions", function () {
       method: 'POST',
       url: `/trips/${tripInst.id}/statuses`,
       payload: {
-        status: 'cancelled'
+        status: 'cancelled',
       },
-      headers
+      headers,
     })
 
     // Failure should be in message
@@ -334,33 +335,33 @@ lab.experiment("Event subscriptions", function () {
 
   lab.test('Validation of unknown fields', {timeout: 10000}, async function () {
     // Some trip data
-    var companyInst = await m.TransportCompany.create({})
-    var routeInst = await m.Route.create({
+    let companyInst = await m.TransportCompany.create({})
+    let routeInst = await m.Route.create({
       transportCompanyId: companyInst.id,
     })
-    var stopInst = await m.Stop.create({
-      coordinates: {type: 'Point', coordinates: randomSingaporeLngLat()}
+    let stopInst = await m.Stop.create({
+      coordinates: {type: 'Point', coordinates: randomSingaporeLngLat()},
     })
-    var tripInst = await m.Trip.create({
+    let tripInst = await m.Trip.create({
       routeId: routeInst.id,
       tripStops: [
         {stopId: stopInst.id, time: '2016-01-01T00:00:00', canBoard: true, canAlight: true},
         {stopId: stopInst.id, time: '2016-01-01T04:00:00', canBoard: true, canAlight: true},
-      ]
+      ],
     }, {include: [m.TripStop]})
 
     // Some event data
     await m.EventSubscription.create({
       agent: {
         telephone: adminInst.telephone,
-        email: adminInst.email
+        email: adminInst.email,
       },
       event: 'tripCancelled',
       formatter: '0',
       params: {routeIds: [routeInst.id], unknownField: 'blah', ignoreIfEmpty: false},
-      handler: 'test'
+      handler: 'test',
     })
-    var login = await loginAs('superadmin')
+    let login = await loginAs('superadmin')
     await server.plugins['daemon-event-subscriptions'].reloadSubscriptions()
 
     // Execute the cancellation
@@ -368,11 +369,11 @@ lab.experiment("Event subscriptions", function () {
       method: 'POST',
       url: `/trips/${tripInst.id}/statuses`,
       payload: {
-        status: 'cancelled'
+        status: 'cancelled',
       },
       headers: {
-        authorization: `Bearer ${login.result.sessionToken}`
-      }
+        authorization: `Bearer ${login.result.sessionToken}`,
+      },
     })
 
     // Failure should be in message
@@ -380,7 +381,7 @@ lab.experiment("Event subscriptions", function () {
   })
 
   lab.test('Authorization of some endpoints', async function () {
-    var subscription = {}
+    let subscription = {}
 
     eventDefinitions.newBooking.authorize({}, 10, subscription)
     expect(subscription.transportCompanyIds[0]).equal(10)
@@ -391,22 +392,22 @@ lab.experiment("Event subscriptions", function () {
 
   lab.test('CRUD subscriptions', async function () {
     // Some trip data
-    var companyInst = await m.TransportCompany.create({})
+    let companyInst = await m.TransportCompany.create({})
     await m.Route.create({
       transportCompanyId: companyInst.id,
     })
     await m.Stop.create({
-      coordinates: {type: 'Point', coordinates: randomSingaporeLngLat()}
+      coordinates: {type: 'Point', coordinates: randomSingaporeLngLat()},
     })
-    var adminInst = await m.Admin.create({
-      email: randomEmail()
+    let adminInst = await m.Admin.create({
+      email: randomEmail(),
     })
     await adminInst.addTransportCompany(companyInst, {permissions: ['manage-notifications', 'update-trip-status']})
 
-    var headers = {
-      authorization: `Bearer ${adminInst.makeToken()}`
+    let headers = {
+      authorization: `Bearer ${adminInst.makeToken()}`,
     }
-    var response
+    let response
 
     // Create subscription
     response = await server.inject({
@@ -419,14 +420,14 @@ lab.experiment("Event subscriptions", function () {
         handler: 'test',
         agent: {
           telephone: adminInst.telephone,
-          email: adminInst.email
+          email: adminInst.email,
         },
       },
-      headers
+      headers,
     })
     expect(response.statusCode).equal(200)
 
-    var subscriptionObject = await m.EventSubscription.findById(response.result.id)
+    let subscriptionObject = await m.EventSubscription.findById(response.result.id)
     expect(subscriptionObject).exist()
 
     // check that authorization has worked, and the set of companies is restricted
@@ -441,23 +442,23 @@ lab.experiment("Event subscriptions", function () {
         handler: 'test',
         agent: {
           telephone: adminInst.telephone,
-          email: adminInst.email
+          email: adminInst.email,
         },
       },
-      headers
+      headers,
     })
     expect(response.statusCode).equal(200)
 
     subscriptionObject = await m.EventSubscription.findById(response.result.id)
     expect(subscriptionObject.params.transportCompanyIds[0]).equal(companyInst.id)
 
-    var createdSubscriptionId = response.result.id
+    let createdSubscriptionId = response.result.id
 
     // Read
     response = await server.inject({
       method: 'GET',
       url: `/companies/${companyInst.id}/eventSubscriptions`,
-      headers
+      headers,
     })
     expect(response.statusCode).equal(200)
     expect(response.result.find(t => t.id === createdSubscriptionId)).exist()
@@ -470,12 +471,12 @@ lab.experiment("Event subscriptions", function () {
         event: 'testEvent',
         params: { string: '2' },
         formatter: '0',
-        handler: 'test'
+        handler: 'test',
       },
-      headers
+      headers,
     })
     expect(response.statusCode).equal(200)
-    var subscrInst = await m.EventSubscription.findById(createdSubscriptionId)
+    let subscrInst = await m.EventSubscription.findById(createdSubscriptionId)
     expect(subscrInst.event).equal('testEvent')
     expect(subscrInst.params.string).equal('2')
 
@@ -483,7 +484,7 @@ lab.experiment("Event subscriptions", function () {
     response = await server.inject({
       method: 'DELETE',
       url: `/companies/${companyInst.id}/eventSubscriptions/${createdSubscriptionId}`,
-      headers
+      headers,
     })
     expect(response.statusCode).equal(200)
     subscrInst = await m.EventSubscription.findById(createdSubscriptionId)
@@ -492,7 +493,7 @@ lab.experiment("Event subscriptions", function () {
 })
 
 lab.experiment("Event handlers", function () {
-  var mocked = {
+  let mocked = {
     sendSMS ({to, from, body}) {
       expect(typeof to).equal('string')
       expect(typeof from).equal('string')
@@ -508,20 +509,20 @@ lab.experiment("Event handlers", function () {
     sendTelegram (chatId, message) {
       expect(typeof message).equal('string')
       expect(/^[0-9]+$/.test(chatId)).equal(true)
-    }
+    },
   }
 
-  var real = {
+  let real = {
     sendSMS: null,
     sendEmail: null,
-    sendTelegram: null
+    sendTelegram: null,
   }
 
   lab.before(async () => {
     real = {
       sendSMS: require('../src/lib/util/sms').sendSMS,
       sendMail: require('../src/lib/util/email').sendMail,
-      sendTelegram: require('../src/lib/util/telegram').sendTelegram
+      sendTelegram: require('../src/lib/util/telegram').sendTelegram,
     }
 
     require('../src/lib/util/sms').sendSMS = mocked.sendSMS
@@ -536,9 +537,9 @@ lab.experiment("Event handlers", function () {
   })
 
   lab.test('Event handlers succeed', async () => {
-    var payload = {
+    let payload = {
       message: 'Hello world!',
-      severity: 3
+      severity: 3,
     }
     eventHandlers.sms(
       {telephone: "+6588881111"},

--- a/test/testToInvestigate.js
+++ b/test/testToInvestigate.js
@@ -146,7 +146,7 @@
 //       url: "/transactions/tickets/payment",
 //       payload: {
 //         trips: purchaseItems1,
-//         creditTag: testTag,
+//         applyRoutePass: true,
 //         stripeToken: await createStripeToken(),
 //       },
 //       headers: authHeaders.user
@@ -158,7 +158,7 @@
 //       url: "/transactions/tickets/payment",
 //       payload: {
 //         trips: purchaseItems2,
-//         creditTag: testTag,
+//         applyRoutePass: true,
 //         stripeToken: 'Fake stripe token',
 //       },
 //       headers: authHeaders.user
@@ -170,7 +170,7 @@
 //       url: "/transactions/tickets/payment",
 //       payload: {
 //         trips: purchaseItems2,
-//         creditTag: testTag,
+//         applyRoutePass: true,
 //         stripeToken: await createStripeToken(),
 //       },
 //       headers: authHeaders.user
@@ -224,7 +224,7 @@
 //       url: `/transactions/route_passes/payment`,
 //       payload: {
 //         value: '5.00',
-//         creditTag: testTag,
+//         tag: testTag,
 //         stripeToken: await createStripeToken(),
 //         companyId
 //       },

--- a/test/transactions.js
+++ b/test/transactions.js
@@ -25,7 +25,7 @@ lab.experiment("Transactions", function () {
   let adminInstance
   let authHeaders = {}
   let stripeTokens = []
-  let creditTag
+  let tag
 
   // var testName = "Name for Testing";
   // var updatedTestName = "Updated name for Testing";
@@ -91,7 +91,7 @@ lab.experiment("Transactions", function () {
   }
 
   lab.before({timeout: 25000}, async () => {
-    creditTag = 'crowdstart-' + randomString()
+    tag = 'crowdstart-' + randomString()
 
     userInstance = await models.User.create({
       email: `testuser${new Date().getTime()}@example.com`,
@@ -128,7 +128,7 @@ lab.experiment("Transactions", function () {
       name: "Test route only",
       from: "FromHere",
       to: "ToHere",
-      tags: [creditTag, 'public'],
+      tags: [tag, 'public'],
       transportCompanyId: companyInstance.id,
     })
 
@@ -626,7 +626,7 @@ lab.experiment("Transactions", function () {
         description: 'Issue 1 Free Pass',
         userId: userInstance.id,
         routeId: routeInstance.id,
-        tag: creditTag,
+        tag,
       },
       headers: authHeaders[role],
     })
@@ -650,7 +650,7 @@ lab.experiment("Transactions", function () {
   lab.test("Issue Free Route Pass - is working for admin", {timeout: 15000}, issueFreeRoutePassWorksFor('admin'))
 
   const issueFreeRoutePassFailsFor = role => async () => {
-    const where = { userId: userInstance.id, companyId: companyInstance.id, tag: creditTag}
+    const where = { userId: userInstance.id, companyId: companyInstance.id, tag: tag}
     const initialRoutePassCount = await routePassCount(where)
 
     let response = await server.inject({
@@ -660,7 +660,7 @@ lab.experiment("Transactions", function () {
         description: 'Issue 1 Free Pass',
         userId: userInstance.id,
         routeId: routeInstance.id,
-        tag: creditTag,
+        tag,
       },
       headers: typeof role === 'string' ? authHeaders[role] : role,
     })
@@ -1620,7 +1620,7 @@ lab.experiment("Transactions", function () {
       url: `/transactions/tickets/${ticket.id}/refund/route_pass`,
       payload: {
         targetAmt: tripPrice,
-        creditTag,
+        tag,
       },
       headers: authHeaders.admin,
     })
@@ -1655,7 +1655,7 @@ lab.experiment("Transactions", function () {
       url: `/transactions/tickets/${ticket.id}/refund/route_pass`,
       payload: {
         targetAmt: tripPrice,
-        creditTag,
+        tag,
       },
       headers: authHeaders.admin,
     })
@@ -1664,7 +1664,7 @@ lab.experiment("Transactions", function () {
     expect(refundResponse2.result.message).equal('Unable to refund to routePass for partially refunded tickets')
   })
 
-  lab.test("Refund RoutePass fails for bad creditTags", {timeout: 30000}, async function () {
+  lab.test("Refund RoutePass fails for bad tags", {timeout: 30000}, async function () {
     const tripPrice = tripInstances[0].price
 
     let saleResponse = await server.inject({
@@ -1705,14 +1705,14 @@ lab.experiment("Transactions", function () {
     await tripInstances[0].reload()
     const seatsAvailable = tripInstances[0].seatsAvailable
 
-    const where = {userId: userInstance.id, companyId: companyInstance.id, tag: creditTag}
+    const where = {userId: userInstance.id, companyId: companyInstance.id, tag}
     const initialRoutePassCount = await routePassCount(where)
 
-    const makeAndValidateBadRefundRequest = async creditTag => {
+    const makeAndValidateBadRefundRequest = async tag => {
       let refundResponse = await server.inject({
         method: "POST",
         url: `/transactions/tickets/${ticket.id}/refund/route_pass`,
-        payload: { creditTag, targetAmt: tripPrice },
+        payload: { tag, targetAmt: tripPrice },
         headers: authHeaders.admin,
       })
 
@@ -1724,7 +1724,7 @@ lab.experiment("Transactions", function () {
     }
 
     // Irrelevant tag
-    await makeAndValidateBadRefundRequest('BADCREDITTAG')
+    await makeAndValidateBadRefundRequest('BADTAG')
     // Non-credit tags
     await makeAndValidateBadRefundRequest('public')
   })
@@ -1763,7 +1763,7 @@ lab.experiment("Transactions", function () {
       url: `/transactions/tickets/${ticket.id}/refund/route_pass`,
       payload: {
         targetAmt: tripPrice - 2,
-        creditTag,
+        tag,
       },
       headers: authHeaders.admin,
     })
@@ -1778,7 +1778,7 @@ lab.experiment("Transactions", function () {
       url: `/transactions/tickets/${ticket.id}/refund/route_pass`,
       payload: {
         targetAmt: tripPrice + 2,
-        creditTag,
+        tag,
       },
       headers: authHeaders.admin,
     })
@@ -1866,7 +1866,7 @@ lab.experiment("Transactions", function () {
       url: `/transactions/tickets/${ticket.id}/refund/route_pass`,
       payload: {
         targetAmt: tripPrice,
-        creditTag,
+        tag,
       },
       headers: authHeaders.admin,
     })
@@ -1918,7 +1918,7 @@ lab.experiment("Transactions", function () {
       url: `/transactions/route_passes/payment`,
       payload: {
         quantity: 1,
-        tag: creditTag,
+        tag,
         stripeToken: await createStripeToken(),
         companyId: companyInstance.id,
       },
@@ -1963,7 +1963,7 @@ lab.experiment("Transactions", function () {
       code: promoCode,
       type: 'RoutePass',
       params: {
-        tag: creditTag,
+        tag,
         qualifyingCriteria: [
           {type: 'noLimit', params: {}},
         ],
@@ -1990,7 +1990,7 @@ lab.experiment("Transactions", function () {
       url: `/transactions/route_passes/payment`,
       payload: {
         quantity: 1,
-        tag: creditTag,
+        tag,
         stripeToken: await createStripeToken(),
         promoCode: { code: promoCode },
         companyId: companyInstance.id,


### PR DESCRIPTION
* Flesh out jsdoc for util/endpoints and prettify
* De-lint credit integration and discounted route pass purchase tests
* Remove references to `creditTag`
* Remove `/payment_ticket_sale` and `/ticket_sale` endpoints
* Prettify `/payment` and `/quote` endpoints, fix up tests