### PR TITLE
 Support the crowdstart-private tag

### DIFF
--- a/src/lib/endpoints/crowdstart.js
+++ b/src/lib/endpoints/crowdstart.js
@@ -25,6 +25,9 @@ export const register = function(server, options, next) {
   routeRequestsTo(server, mapToRoots("/status"), {
     method: "GET",
     config: {
+      auth: {
+        access: { scope: ["public", "user", "admin", "superadmin"] },
+      },
       tags: ["api"],
       validate: {
         query: {
@@ -37,10 +40,19 @@ export const register = function(server, options, next) {
     async handler(request, reply) {
       try {
         let m = getModels(request)
-
+        const isAdmin = ["admin", "superadmin"].includes(
+          request.auth.credentials.scope
+        )
         let crowdstartQuery = {
           where: {
-            tags: { $contains: ["crowdstart"] },
+            tags: isAdmin
+              ? {
+                  $or: [
+                    { $contains: ["crowdstart"] },
+                    { $contains: ["crowdstart-private"] },
+                  ],
+                }
+              : { $contains: ["crowdstart"] },
           },
           include: [
             {

--- a/src/lib/endpoints/crowdstart.js
+++ b/src/lib/endpoints/crowdstart.js
@@ -331,7 +331,7 @@ marking all bids on this route as 'failed'
         },
       },
       auth: {
-        access: { scope: ["public", "admin", "superadmin"] },
+        access: { scope: ["public", "user", "admin", "superadmin"] },
       },
       tags: ["api"],
       description: `Returns all bids made for a given route`,
@@ -339,7 +339,7 @@ marking all bids on this route as 'failed'
     handler: handleRequestWith(
       request => getModels(request).Route.findById(request.params.routeId),
       async (route, request) => {
-        if (request.auth.credentials.scope !== "public") {
+        if (!["public", "user"].includes(request.auth.credentials.scope)) {
           await auth.assertAdminRole(
             request.auth.credentials,
             "manage-routes",
@@ -353,7 +353,7 @@ marking all bids on this route as 'failed'
         const params = {
           where: { routeId: route.id },
         }
-        if (request.auth.credentials.scope !== "public") {
+        if (["public", "user"].includes(request.auth.credentials.scope)) {
           params.include = [
             {
               model: m.User,

--- a/src/lib/models/Bid.js
+++ b/src/lib/models/Bid.js
@@ -61,8 +61,9 @@ export default modelCache => {
               userInst.savedPaymentInfo.default_source,
             "You need to provide payment information."
           )
+          const { tags } = routeInst
           TransactionError.assert(
-            routeInst.tags.includes("crowdstart"),
+            tags.includes("crowdstart") || tags.includes("crowdstart-private"),
             "Selected route is not a crowdstart route"
           )
 


### PR DESCRIPTION
* `GET /routes/{id}/bids` - Ensure that user credentials scope is covered
* Recognise the tag crowdstart-private in `Bid.createForUserAndRoute`
and `/crowdstart/status`
* `/crowdstart/status` - return crowdstart-private only if the requester has an
admin scope