### PR TITLE
Prevent booking tickets on non-ticketing routes

### DIFF
--- a/src/lib/transactions/builder.js
+++ b/src/lib/transactions/builder.js
@@ -676,6 +676,16 @@ export async function initBuilderWithTicketSale(connection, lineItems) {
     ],
   })
 
+  const nonTicketingTags = _(trips)
+    .flatMap(trip => trip.route.tags)
+    .filter(tag => tag === "crowdstart" || tag === "lite")
+    .value()
+
+  TransactionError.assert(
+    nonTicketingTags.length === 0,
+    `Ticket purchase includes non-ticketing routes of the following types: ${nonTicketingTags}`
+  )
+
   const tripsById = _.keyBy(trips, "id")
 
   _.assign(transactionBuilder, { tripsById, trips })


### PR DESCRIPTION
`initBuilderWithTicketSale()` - assert we have no crowdstart or lite routes,
to prevent ticket purchases on those