### PR TITLE
Exclude terms features by default from companies list

### DIFF
--- a/src/lib/endpoints/companies.js
+++ b/src/lib/endpoints/companies.js
@@ -36,9 +36,7 @@ export const register = function register(server, options, next) {
 
     handler: function(request, reply) {
       let m = common.getModels(request)
-      m.TransportCompany.findAll({
-        attributes: { exclude: ["logo"] },
-      }).then(resp => {
+      m.TransportCompany.findAll().then(resp => {
         reply(
           resp.map(x => {
             return cleanCompanyInfo(x.toJSON())
@@ -62,9 +60,10 @@ export const register = function register(server, options, next) {
     },
     handler: function(request, reply) {
       let m = common.getModels(request)
-      m.TransportCompany.findById(request.params.id, {
-        attributes: { exclude: ["logo"] },
-      })
+      m.TransportCompany.unscoped()
+        .findById(request.params.id, {
+          attributes: { exclude: ["logo"] },
+        })
         .then(resp => {
           if (!resp) return reply(Boom.notFound())
           reply(cleanCompanyInfo(resp.toJSON()))
@@ -141,7 +140,9 @@ export const register = function register(server, options, next) {
     async handler(request, reply) {
       try {
         let m = common.getModels(request)
-        let companyInst = await m.TransportCompany.findById(request.params.id)
+        let companyInst = await m.TransportCompany.unscoped().findById(
+          request.params.id
+        )
 
         await auth.assertAdminRole(
           request.auth.credentials,

--- a/src/lib/models/TransportCompany.js
+++ b/src/lib/models/TransportCompany.js
@@ -1,67 +1,71 @@
-import ssaclAttributeRoles from 'ssacl-attribute-roles'
+import ssaclAttributeRoles from "ssacl-attribute-roles"
 
-export default function (modelCache) {
-  var DataTypes = modelCache.db.Sequelize
-  var Company = modelCache.db.define('transportCompany', {
-    type: DataTypes.INTEGER,
-    logo: DataTypes.BLOB,
-    name: DataTypes.STRING(50),
-    email: DataTypes.STRING(50),
-    contactNo: DataTypes.STRING(50),
-    smsOpCode: {
-      type: DataTypes.STRING(11),
-      allowNull: true,
-    },
-    features: DataTypes.TEXT,
-    terms: DataTypes.TEXT,
-    clientId: {
-      type: DataTypes.STRING,
-      roles: false,
-    },
-    clientSecret: {
-      type: DataTypes.STRING,
-      roles: false,
-    },
-    sandboxId: {
-      type: DataTypes.STRING,
-      roles: false,
-    },
-    sandboxSecret: {
-      type: DataTypes.STRING,
-      roles: false,
-    },
-    /* We don't leak the client id to users of the API, so we
+export default function(modelCache) {
+  let DataTypes = modelCache.db.Sequelize
+  let Company = modelCache.db.define(
+    "transportCompany",
+    {
+      type: DataTypes.INTEGER,
+      logo: DataTypes.BLOB,
+      name: DataTypes.STRING(50),
+      email: DataTypes.STRING(50),
+      contactNo: DataTypes.STRING(50),
+      smsOpCode: {
+        type: DataTypes.STRING(11),
+        allowNull: true,
+      },
+      features: DataTypes.TEXT,
+      terms: DataTypes.TEXT,
+      clientId: {
+        type: DataTypes.STRING,
+        roles: false,
+      },
+      clientSecret: {
+        type: DataTypes.STRING,
+        roles: false,
+      },
+      sandboxId: {
+        type: DataTypes.STRING,
+        roles: false,
+      },
+      sandboxSecret: {
+        type: DataTypes.STRING,
+        roles: false,
+      },
+      /* We don't leak the client id to users of the API, so we
        leak the presence of it instead */
-    hasClientId: {
-      type: DataTypes.VIRTUAL,
-      get () {
-        return !!this.getDataValue('clientId')
-      }
+      hasClientId: {
+        type: DataTypes.VIRTUAL,
+        get() {
+          return !!this.getDataValue("clientId")
+        },
+      },
+      referrer: DataTypes.STRING,
+      status: DataTypes.STRING,
     },
-    referrer: DataTypes.STRING,
-    status: DataTypes.STRING
-  }, {
-    defaultScope: {
-      attributes: { exclude: ['logo', 'features', 'terms'] } // exclude by default the heavy attributes
+    {
+      defaultScope: {
+        attributes: { exclude: ["logo", "features", "terms"] }, // exclude by default the heavy attributes
+      },
     }
-  })
+  )
 
   ssaclAttributeRoles(Company)
   return Company
 }
 
-export function makeAssociation (modelCache) {
-  var Driver = modelCache.require('Driver')
-  var TransportCompany = modelCache.require('TransportCompany')
-  var DriverCompany = modelCache.require('DriverCompany')
-  var ContactList = modelCache.require('ContactList')
+export function makeAssociation(modelCache) {
+  let Driver = modelCache.require("Driver")
+  let TransportCompany = modelCache.require("TransportCompany")
+  let DriverCompany = modelCache.require("DriverCompany")
+  let ContactList = modelCache.require("ContactList")
 
   TransportCompany.belongsToMany(Driver, {
     through: DriverCompany,
-    foreignKey: "transportCompanyId"
+    foreignKey: "transportCompanyId",
   })
 
   TransportCompany.hasMany(ContactList, {
-    foreignKey: "transportCompanyId"
+    foreignKey: "transportCompanyId",
   })
 }

--- a/src/lib/models/TransportCompany.js
+++ b/src/lib/models/TransportCompany.js
@@ -40,6 +40,10 @@ export default function (modelCache) {
     },
     referrer: DataTypes.STRING,
     status: DataTypes.STRING
+  }, {
+    defaultScope: {
+      attributes: { exclude: ['logo', 'features', 'terms'] } // exclude by default the heavy attributes
+    }
   })
 
   ssaclAttributeRoles(Company)

--- a/src/lib/models/TransportCompany.js
+++ b/src/lib/models/TransportCompany.js
@@ -1,5 +1,10 @@
 import ssaclAttributeRoles from "ssacl-attribute-roles"
 
+/**
+ * Returns the model for a TransportCompany
+ * @param {object} modelCache
+ * @return {Model}
+ */
 export default function(modelCache) {
   let DataTypes = modelCache.db.Sequelize
   let Company = modelCache.db.define(
@@ -7,11 +12,11 @@ export default function(modelCache) {
     {
       type: DataTypes.INTEGER,
       logo: DataTypes.BLOB,
-      name: DataTypes.STRING(50),
-      email: DataTypes.STRING(50),
-      contactNo: DataTypes.STRING(50),
+      name: DataTypes.STRING(50), // eslint-disable-line
+      email: DataTypes.STRING(50), // eslint-disable-line
+      contactNo: DataTypes.STRING(50), // eslint-disable-line
       smsOpCode: {
-        type: DataTypes.STRING(11),
+        type: DataTypes.STRING(11), // eslint-disable-line
         allowNull: true,
       },
       features: DataTypes.TEXT,
@@ -54,6 +59,10 @@ export default function(modelCache) {
   return Company
 }
 
+/**
+ *
+ * @param {object} modelCache
+ */
 export function makeAssociation(modelCache) {
   let Driver = modelCache.require("Driver")
   let TransportCompany = modelCache.require("TransportCompany")

--- a/test/companies.js
+++ b/test/companies.js
@@ -58,6 +58,10 @@ lab.experiment("Company manipulation", function () {
       url: "/companies",
     })
     expect(resp.result.find(c => c.id === companyId)).exist()
+    // ensure heavy attributes are not included
+    expect(resp.result.find(c => 'terms' in c)).undefined()
+    expect(resp.result.find(c => 'features' in c)).undefined()
+    expect(resp.result.find(c => 'logo' in c)).undefined()
 
     // READ
     resp = await server.inject({

--- a/test/companies.js
+++ b/test/companies.js
@@ -11,30 +11,30 @@ const querystring = require('querystring')
 const {loginAs, randomEmail} = require("./test_common")
 const {models: m} = require("../src/lib/core/dbschema")()
 
-var testData = require("./test_data")
+let testData = require("./test_data")
 
 lab.experiment("Company manipulation", function () {
-  var companyId = null
+  let companyId = null
   /* test data */
-  var companyInfo = testData.companies[0]
-  var updatedCompanyInfo = testData.companies[1]
+  let companyInfo = testData.companies[0]
+  let updatedCompanyInfo = testData.companies[1]
 
   lab.before({timeout: 5000}, async function () {
   })
 
   lab.test("CRUD Companies", async function () {
     // LOGIN as superadmin
-    var loginResponse = await loginAs('superadmin')
-    var superAuthHeaders = {
-      authorization: "Bearer " + loginResponse.result.sessionToken
+    let loginResponse = await loginAs('superadmin')
+    let superAuthHeaders = {
+      authorization: "Bearer " + loginResponse.result.sessionToken,
     }
 
-    var resp = await server.inject({
+    let resp = await server.inject({
       method: "POST",
       url: "/companies",
       // Omit because these should be done via Stripe connect
       payload: _.omit(companyInfo, ['clientId', 'clientSecret', 'sandboxSecret', 'sandboxId']),
-      headers: superAuthHeaders
+      headers: superAuthHeaders,
     })
     expect(resp.statusCode).to.equal(200)
     expect(resp.result).to.include("id")
@@ -48,21 +48,21 @@ lab.experiment("Company manipulation", function () {
       transportCompanyId: companyId,
       permissions: ['manage-company'],
     })
-    var authHeaders = {
-      authorization: "Bearer " + loginResponse.result.sessionToken
+    let authHeaders = {
+      authorization: "Bearer " + loginResponse.result.sessionToken,
     }
 
     // LIST
     resp = await server.inject({
       method: "GET",
-      url: "/companies"
+      url: "/companies",
     })
     expect(resp.result.find(c => c.id === companyId)).exist()
 
     // READ
     resp = await server.inject({
       method: "GET",
-      url: "/companies/" + companyId
+      url: "/companies/" + companyId,
     })
 
     expect(resp.statusCode).to.equal(200)
@@ -84,7 +84,7 @@ lab.experiment("Company manipulation", function () {
 
     resp = await server.inject({
       method: "GET",
-      url: "/companies/" + companyId
+      url: "/companies/" + companyId,
     })
     delete updatedCompanyInfo.clientSecret
     delete updatedCompanyInfo.sandboxSecret
@@ -95,23 +95,23 @@ lab.experiment("Company manipulation", function () {
     resp = await server.inject({
       method: "DELETE",
       url: "/companies/" + companyId,
-      headers: superAuthHeaders
+      headers: superAuthHeaders,
     })
     expect(resp.statusCode).to.equal(200)
 
     resp = await server.inject({
       method: "GET",
-      url: "/companies/" + companyId
+      url: "/companies/" + companyId,
     })
     expect(resp.statusCode).to.equal(404)
   })
 
   lab.test('Stripe Connect (partial test)', async function () {
-    var adminEmail = randomEmail()
-    var adminInst = await m.Admin.create({
-      email: adminEmail
+    let adminEmail = randomEmail()
+    let adminInst = await m.Admin.create({
+      email: adminEmail,
     })
-    var companyInst = await m.TransportCompany.create({})
+    let companyInst = await m.TransportCompany.create({})
 
     await adminInst.addTransportCompany(companyInst.id, {permissions: ['manage-company']})
 
@@ -120,11 +120,11 @@ lab.experiment("Company manipulation", function () {
       method: 'POST',
       url: `/companies/${companyInst.id}/stripeConnect`,
       headers: {
-        authorization: `Bearer ${adminInst.makeToken()}`
+        authorization: `Bearer ${adminInst.makeToken()}`,
       },
       payload: {
-        redirect: 'https://redirect.example.com/'
-      }
+        redirect: 'https://redirect.example.com/',
+      },
     })
 
     let urlResult = URL.parse(response.result, true)
@@ -142,7 +142,7 @@ lab.experiment("Company manipulation", function () {
 
     // The actual connecting part
     // Monkey-patch the connectAccount method, since we can't test that
-    var originalConnectMethod = require('../src/lib/transactions/payment').connectAccount
+    let originalConnectMethod = require('../src/lib/transactions/payment').connectAccount
 
     require('../src/lib/transactions/payment').connectAccount = async function (code) {
       expect(code).equal('TEST_TEST_OAUTH_CODE')
@@ -159,10 +159,10 @@ lab.experiment("Company manipulation", function () {
         url: `/companies/stripeConnect?` + querystring.stringify({
           code: 'TEST_TEST_FAKE_CODE',
           state: urlResult.query.state,
-          scope: 'read_write'
+          scope: 'read_write',
         }),
         headers: {
-          authorization: `Bearer ${adminInst.makeToken()}`
+          authorization: `Bearer ${adminInst.makeToken()}`,
         },
       })
       expect(invalidResponse1.statusCode).equal(500)
@@ -174,10 +174,10 @@ lab.experiment("Company manipulation", function () {
         url: `/companies/stripeConnect?` + querystring.stringify({
           code: 'TEST_TEST_OAUTH_CODE',
           state: urlResult.query.state.substr(0, urlResult.query.state.length - 10),
-          scope: 'read_write'
+          scope: 'read_write',
         }),
         headers: {
-          authorization: `Bearer ${adminInst.makeToken()}`
+          authorization: `Bearer ${adminInst.makeToken()}`,
         },
       })
       expect(invalidResponse2.statusCode).equal(403)
@@ -189,10 +189,10 @@ lab.experiment("Company manipulation", function () {
         url: `/companies/stripeConnect?` + querystring.stringify({
           code: 'TEST_TEST_OAUTH_CODE',
           state: urlResult.query.state,
-          scope: 'read_write'
+          scope: 'read_write',
         }),
         headers: {
-          authorization: `Bearer ${adminInst.makeToken()}`
+          authorization: `Bearer ${adminInst.makeToken()}`,
         },
       })
       expect(connectResponse.statusCode).equal(302)


### PR DESCRIPTION
By parking the exclusion under the `defaultScope`, this will also exclude the same attributes from being included elsewhere, notably the admin view endpoints