### PR TITLE
allow personal suggestions to be listed

### DIFF
--- a/src/lib/endpoints/suggestions.js
+++ b/src/lib/endpoints/suggestions.js
@@ -122,7 +122,7 @@ export function register(server, options, next) {
 
   server.route({
     method: "GET",
-    path: "/allSuggestions",
+    path: "/all_suggestions",
     config: {
       tags: ["api"],
       validate: {

--- a/src/lib/endpoints/suggestions.js
+++ b/src/lib/endpoints/suggestions.js
@@ -105,6 +105,26 @@ export function register(server, options, next) {
     path: "/suggestions",
     config: {
       tags: ["api"],
+      auth: { access: {scope: ['user']}},
+    },
+    handler: handleRequestWith(
+      (ig, request, { models }) =>
+        models.Suggestion.findAll({
+          where: {
+            userId: request.auth.credentials.userId,
+          },
+          order: [["id", "DESC"]],
+          limit: request.query.limit,
+        }),
+      s => s.map(t => t.toJSON())
+    ),
+  })
+
+  server.route({
+    method: "GET",
+    path: "/allSuggestions",
+    config: {
+      tags: ["api"],
       validate: {
         query: {
           lastId: Joi.number().optional(),

--- a/src/lib/endpoints/suggestions.js
+++ b/src/lib/endpoints/suggestions.js
@@ -105,7 +105,7 @@ export function register(server, options, next) {
     path: "/suggestions",
     config: {
       tags: ["api"],
-      auth: { access: {scope: ['user']}},
+      auth: { access: { scope: ["user"] } },
     },
     handler: handleRequestWith(
       (ig, request, { models }) =>

--- a/test/suggestions.js
+++ b/test/suggestions.js
@@ -90,18 +90,35 @@ lab.experiment("Suggestion manipulation", function () {
     expect(singleResult.result.alight.coordinates[0]).equal(104.0)
     expect(singleResult.result.board.coordinates[0]).equal(103.1)
 
-    // Superadmin fetch
-    const superadminFetchResponse = await server.inject({
+    // Fetch personal suggestions
+    const superadminFetchPersonalResponse = await server.inject({
       url: "/suggestions",
+      method: "GET",
+      headers: userHeaders,
+    })
+    expect(superadminFetchPersonalResponse.result.length).equal(3)
+    expect(superadminFetchPersonalResponse.result.every(r => r.userId === user.id))
+
+    // User 2 fetch personal suggestions --> no results
+    const user2FetchPersonalResponse = await server.inject({
+      url: "/suggestions",
+      method: "GET",
+      headers: {Authorization: `Bearer ${user2.makeToken()}`},
+    })
+    expect(user2FetchPersonalResponse.result.length).equal(0)
+
+    // Superadmin fetch all suggestions
+    const superadminFetchResponse = await server.inject({
+      url: "/allSuggestions",
       method: "GET",
       headers: superadminHeaders,
     })
     expect(superadminFetchResponse.result.length).equal(3)
     expect(superadminFetchResponse.result.every(r => r.userId === user.id))
 
-    // User 2 fetch
+    // User 2 fetch all suggestions
     const user2FetchResponse = await server.inject({
-      url: "/suggestions",
+      url: "/allSuggestions",
       method: "GET",
       headers: {Authorization: `Bearer ${user2.makeToken()}`},
     })

--- a/test/suggestions.js
+++ b/test/suggestions.js
@@ -128,7 +128,7 @@ lab.experiment("Suggestion manipulation", function () {
     // Last ID fetch
     const maxId = _.max(responses.map(r => r.result.id))
     const lastIdFetchResponse = await server.inject({
-      url: "/suggestions?" + querystring.stringify({
+      url: "/allSuggestions?" + querystring.stringify({
         lastId: maxId,
       }),
       method: "GET",

--- a/test/suggestions.js
+++ b/test/suggestions.js
@@ -109,7 +109,7 @@ lab.experiment("Suggestion manipulation", function () {
 
     // Superadmin fetch all suggestions
     const superadminFetchResponse = await server.inject({
-      url: "/allSuggestions",
+      url: "/all_suggestions",
       method: "GET",
       headers: superadminHeaders,
     })
@@ -118,7 +118,7 @@ lab.experiment("Suggestion manipulation", function () {
 
     // User 2 fetch all suggestions
     const user2FetchResponse = await server.inject({
-      url: "/allSuggestions",
+      url: "/all_suggestions",
       method: "GET",
       headers: {Authorization: `Bearer ${user2.makeToken()}`},
     })
@@ -128,7 +128,7 @@ lab.experiment("Suggestion manipulation", function () {
     // Last ID fetch
     const maxId = _.max(responses.map(r => r.result.id))
     const lastIdFetchResponse = await server.inject({
-      url: "/allSuggestions?" + querystring.stringify({
+      url: "/all_suggestions?" + querystring.stringify({
         lastId: maxId,
       }),
       method: "GET",

--- a/test/suggestions.js
+++ b/test/suggestions.js
@@ -91,13 +91,13 @@ lab.experiment("Suggestion manipulation", function () {
     expect(singleResult.result.board.coordinates[0]).equal(103.1)
 
     // Fetch personal suggestions
-    const superadminFetchPersonalResponse = await server.inject({
+    const userFetchPersonalResponse = await server.inject({
       url: "/suggestions",
       method: "GET",
       headers: userHeaders,
     })
-    expect(superadminFetchPersonalResponse.result.length).equal(3)
-    expect(superadminFetchPersonalResponse.result.every(r => r.userId === user.id))
+    expect(userFetchPersonalResponse.result.length).equal(3)
+    expect(userFetchPersonalResponse.result.every(r => r.userId === user.id))
 
     // User 2 fetch personal suggestions --> no results
     const user2FetchPersonalResponse = await server.inject({


### PR DESCRIPTION
So,... if a user wants to see his suggestions, it's GET /suggestions. If a user wants to see *all* suggestions by everybody, it's GET /allSuggestions. Does this API make sense?