### PR TITLE
Don't displaying absorbed charge when there's rounding error

### DIFF
--- a/src/lib/transactions/index.js
+++ b/src/lib/transactions/index.js
@@ -782,7 +782,7 @@ function checkExpectedPrice(tb, price) {
 function absorbSmallPayments(tb) {
   const excess = tb._excessCredit()
 
-  if (excess > 0 && excess * 100 <= Payment.minTransactionChargeInCents()) {
+  if (excess > 0.0001 && excess * 100 <= Payment.minTransactionChargeInCents()) {
     const clone = new TransactionBuilder(tb)
 
     const outstandingAmountsList = outstandingAmounts(clone.items)


### PR DESCRIPTION
Swee Chin fed back that there were some instances where the absorbed charge seems to be $0.